### PR TITLE
Enhanced support for show cdp import tool.

### DIFF
--- a/datastore/importers/nmdb-import-show-cdp-neighbor/CMakeLists.txt
+++ b/datastore/importers/nmdb-import-show-cdp-neighbor/CMakeLists.txt
@@ -34,3 +34,17 @@ target_link_libraries(${TGT_TOOL}
   )
 
 nm_install_bin(${TGT_TOOL})
+
+foreach(ITEM
+    Parser
+  )
+  nm_add_test(${ITEM})
+  target_sources(${TGT_TEST}
+    PRIVATE
+      ${ITEM}.hpp
+      ${ITEM}.cpp
+    )
+  target_link_libraries(${TGT_TEST}
+      netmeld-datastore
+    )
+endforeach()

--- a/datastore/importers/nmdb-import-show-cdp-neighbor/Parser.cpp
+++ b/datastore/importers/nmdb-import-show-cdp-neighbor/Parser.cpp
@@ -49,23 +49,23 @@ Parser::Parser() : Parser::base_type(start)
     +qi::ascii::char_("-") > qi::eol
     ;
 
-	deviceData =
+  deviceData =
     +( hostnameValue
      | ipAddressValue
      | platformValue
      | interfaceValue
      | ((!header) >> ignoredLine)
     )
-		;
+    ;
 
-	hostnameValue =
+  hostnameValue =
     (  (qi::lit("Device") > (qi::space | qi::lit('-')) > qi::lit("ID:"))
      | (qi::lit("SysName:"))
     ) > -qi::space
     > token [pnx::bind(&NeighborData::curHostname, &nd)
              = pnx::bind(&nmcu::toLower, qi::_1)]
     > qi::eol
-		;
+    ;
 
   ipAddressValue =
     qi::lit("IP") > -(qi::lit("v") > qi::char_("46")) > qi::space

--- a/datastore/importers/nmdb-import-show-cdp-neighbor/Parser.cpp
+++ b/datastore/importers/nmdb-import-show-cdp-neighbor/Parser.cpp
@@ -38,7 +38,8 @@ Parser::Parser() : Parser::base_type(start)
     ;
 
   config =
-    *(qi::eol) >> *(header >> deviceData)
+    *(qi::eol)
+    >> *(header >> deviceData) [pnx::bind(&Parser::finalizeData, this)]
     ;
 
   header =
@@ -58,50 +59,34 @@ Parser::Parser() : Parser::base_type(start)
     (  (qi::lit("Device") > (qi::space | qi::lit('-')) > qi::lit("ID:"))
      | (qi::lit("SysName:"))
     ) > -qi::space
-    > token// [pnx::bind(&Parser::hostname, this) = qi::_1]
+    > token [pnx::bind(&NeighborData::curHostname, &nd) = qi::_1]
     > qi::eol
 		;
 
   ipAddressValue =
     qi::lit("IP") > -(qi::lit("v") > qi::char_("46")) > qi::space
     > -qi::lit("address: ")
-    > ipAddr// [pnx::bind(&Parser::addIp, this, qi::_1)]
+    > ipAddr
+      [pnx::bind([&](nmdo::IpAddress val){nd.ipAddrs.push_back(val);}, qi::_1)]
     > *(qi::blank > token)
     > qi::eol
     ;
 
   platformValue =
     qi::lit("Platform: ")
-    // TODO update, could be just model, no vendor
-    > token > qi::space > token
+    > token [pnx::bind(&NeighborData::curVendor, &nd) = qi::_1]
+    > qi::space
+    > token [pnx::bind(&NeighborData::curModel, &nd) = qi::_1]
     > *(qi::blank > token)
     > qi::eol
     ;
 
   interfaceValue =
     qi::lit("Interface: ") > token
-    > qi::lit(" Port ID (outgoing port): ") > token
+    > qi::lit(" Port ID (outgoing port): ")
+    > token [pnx::bind(&NeighborData::curIfaceName, &nd) = qi::_1]
     > qi::eol
     ;
-
-//  devIdAddr =
-//    (qi::lit("Device ID:") >>
-//      hostname >> qi::eol >>
-//     qi::lit("Entry address(es):") >> qi::eol >>
-//     qi::lit("IP address:") >>
-//      ipAddr >> qi::eol >>
-//     qi::lit("Platform:") >>
-//      token >>
-//      token >> qi::omit[+token] >> qi::eol >>
-//     qi::lit("Interface:") >>
-//      token >> qi::lit("Port ID (outgoing port):") >>
-//      token >> qi::eol
-//    ) [
-//       pnx::bind(&Parser::addIp, this, qi::_1, qi::_2),
-//       pnx::bind(&Parser::addHwInfo, this, qi::_1, qi::_3, qi::_4),
-//       pnx::bind(&Parser::addCon, this, qi::_1, qi::_6, qi::_2)
-//      ]
-//    ;
 
   token =
     +qi::ascii::graph
@@ -114,9 +99,12 @@ Parser::Parser() : Parser::base_type(start)
   BOOST_SPIRIT_DEBUG_NODES(
       //(start)
       (config)
-      (header)
-      (devIdAddr)
-      (token)
+      (header) (deviceData)
+      (hostnameValue)
+      (ipAddressValue)
+      (platformValue)
+      (interfaceValue)
+      //(ignoredLine) (token)
       );
 }
 
@@ -130,48 +118,60 @@ Parser::getDevice(const std::string& hostname)
 }
 
 void
-Parser::addIp(const std::string& hostname, const nmdo::IpAddress& _ip)
+Parser::updateIpAddrs()
 {
-  nmdo::IpAddress ip = _ip;
-  ip.addAlias(hostname, "cdp");
-
-  d.ipAddrs.push_back(ip);
-}
-
-void
-Parser::addHwInfo(const std::string& hostname, const std::string& vendor,
-                  std::string& model)
-{
-  nmdo::DeviceInformation devInfo;
-
-  devInfo.setDeviceId(getDevice(hostname));
-  devInfo.setVendor(vendor);
-  if (model.back() == ',') {
-    model.pop_back();
+  for (auto& ip : nd.ipAddrs) {
+    ip.addAlias(nd.curHostname, "cdp import");
+    d.ipAddrs.push_back(ip);
   }
-  devInfo.setModel(model);
-
-  d.devInfos.push_back(devInfo);
 }
 
 void
-Parser::addCon(const std::string& hostname,
-               const std::string& toIface, const nmdo::IpAddress& _ip)
+Parser::updateInterfaces()
 {
-  nmdo::InterfaceNetwork iface {toIface};
+  nmdo::InterfaceNetwork iface {nd.curIfaceName};
   iface.setPartial(true);
 
-  nmdo::IpAddress ip = _ip; // copy to ensure we don't alter original
+  for (auto& ip : nd.ipAddrs) {
+    iface.addIpAddress(ip);
+  }
 
+  d.interfaces.emplace_back(iface, getDevice(nd.curHostname));
+}
+
+void
+Parser::updateDeviceInformation()
+{
   nmdo::DeviceInformation devInfo;
-  const auto& did {getDevice(hostname)};
-  devInfo.setDeviceId(did);
+
+  devInfo.setDeviceId(getDevice(nd.curHostname));
+
+  if (',' == nd.curVendor.back()) {
+    nd.curVendor.pop_back();
+  } else if (nd.curModel.back() == ',') {
+    nd.curModel.pop_back();
+  }
+
+  if (nd.curModel.empty()) {
+    devInfo.setModel(nd.curVendor);
+  } else {
+    devInfo.setVendor(nd.curVendor);
+    devInfo.setModel(nd.curModel);
+  }
+
   d.devInfos.push_back(devInfo);
+}
 
-  ip.addAlias(hostname, "cdp");
-  iface.addIpAddress(ip);
+void
+Parser::finalizeData()
+{
+  if (!nd.curHostname.empty()) {
+    updateIpAddrs();
+    updateInterfaces();
+    updateDeviceInformation();
+  }
 
-  d.interfaces.emplace_back(iface, did);
+  nd = NeighborData();
 }
 
 // Object return

--- a/datastore/importers/nmdb-import-show-cdp-neighbor/Parser.cpp
+++ b/datastore/importers/nmdb-import-show-cdp-neighbor/Parser.cpp
@@ -38,11 +38,7 @@ Parser::Parser() : Parser::base_type(start)
     ;
 
   config =
-    *(qi::eol)
-    >> *(header >> deviceData
-      //devIdAddr >>
-     >> *((!header) >> -qi::omit[+token] >> qi::eol)
-    )
+    *(qi::eol) >> *(header >> deviceData)
     ;
 
   header =
@@ -51,30 +47,34 @@ Parser::Parser() : Parser::base_type(start)
 
 	deviceData =
     +( hostnameValue
-     | ipAddressValue 
+     | ipAddressValue
      | platformValue
      | interfaceValue
-     | ((!header) > ignoredLine)
+     | ((!header) >> ignoredLine)
     )
 		;
 
 	hostnameValue =
     (  (qi::lit("Device") > (qi::space | qi::lit('-')) > qi::lit("ID:"))
      | (qi::lit("SysName:"))
-    ) > -qi::space > token > qi::eol
+    ) > -qi::space
+    > token// [pnx::bind(&Parser::hostname, this) = qi::_1]
+    > qi::eol
 		;
 
   ipAddressValue =
     qi::lit("IP") > -(qi::lit("v") > qi::char_("46")) > qi::space
-    > -qi::lit("address: ") > ipAddr
+    > -qi::lit("address: ")
+    > ipAddr// [pnx::bind(&Parser::addIp, this, qi::_1)]
     > *(qi::blank > token)
     > qi::eol
     ;
 
   platformValue =
-    qi::lit("Platform: ") > token
-    > qi::space > token
-    > +(qi::blank > token)
+    qi::lit("Platform: ")
+    // TODO update, could be just model, no vendor
+    > token > qi::space > token
+    > *(qi::blank > token)
     > qi::eol
     ;
 

--- a/datastore/importers/nmdb-import-show-cdp-neighbor/Parser.cpp
+++ b/datastore/importers/nmdb-import-show-cdp-neighbor/Parser.cpp
@@ -24,8 +24,11 @@
 // Maintained by Sandia National Laboratories <Netmeld@sandia.gov>
 // =============================================================================
 
+#include <netmeld/core/utils/StringUtilities.hpp>
+
 #include "Parser.hpp"
 
+namespace nmcu = netmeld::core::utils;
 
 // =============================================================================
 // Parser logic
@@ -59,7 +62,8 @@ Parser::Parser() : Parser::base_type(start)
     (  (qi::lit("Device") > (qi::space | qi::lit('-')) > qi::lit("ID:"))
      | (qi::lit("SysName:"))
     ) > -qi::space
-    > token [pnx::bind(&NeighborData::curHostname, &nd) = qi::_1]
+    > token [pnx::bind(&NeighborData::curHostname, &nd)
+             = pnx::bind(&nmcu::toLower, qi::_1)]
     > qi::eol
 		;
 
@@ -120,7 +124,8 @@ Parser::getDevice(const std::string& hostname)
 void
 Parser::updateIpAddrs()
 {
-  for (auto& ip : nd.ipAddrs) {
+  // NOTE: want a copy, else interface propagates wrong (alias, reason)
+  for (auto ip : nd.ipAddrs) {
     ip.addAlias(nd.curHostname, "cdp import");
     d.ipAddrs.push_back(ip);
   }

--- a/datastore/importers/nmdb-import-show-cdp-neighbor/Parser.hpp
+++ b/datastore/importers/nmdb-import-show-cdp-neighbor/Parser.hpp
@@ -103,9 +103,6 @@ class Parser :
   // ===========================================================================
   private:
     std::string getDevice(const std::string&);
-    void addIp(const std::string&, const nmdo::IpAddress&);
-    void addHwInfo(const std::string&, const std::string&, std::string&);
-    void addCon(const std::string&, const std::string&, const nmdo::IpAddress&);
 
     void updateIpAddrs();
     void updateInterfaces();

--- a/datastore/importers/nmdb-import-show-cdp-neighbor/Parser.hpp
+++ b/datastore/importers/nmdb-import-show-cdp-neighbor/Parser.hpp
@@ -48,6 +48,14 @@ struct Data {
 };
 typedef std::vector<Data>  Result;
 
+struct NeighborData {
+  std::string curHostname   {""};
+  std::string curIfaceName  {""};
+  std::string curVendor     {""};
+  std::string curModel      {""};
+  std::vector<nmdo::IpAddress>  ipAddrs;
+};
+
 
 // =============================================================================
 // Parser definition
@@ -59,9 +67,10 @@ class Parser :
   // Variables
   // ===========================================================================
   private:
-  protected:
     Data d;
+    NeighborData nd;
 
+  protected:
     // Rules
     qi::rule<nmdp::IstreamIter, Result(), qi::ascii::blank_type>
       start;
@@ -70,8 +79,7 @@ class Parser :
       config,
       header,
       deviceData,
-      ignoredLine,
-      devIdAddr;
+      ignoredLine;
 
     qi::rule<nmdp::IstreamIter>
       hostnameValue,
@@ -83,7 +91,6 @@ class Parser :
       token;
 
     nmdp::ParserIpAddress   ipAddr;
-    nmdp::ParserDomainName  hostname;
 
   // ===========================================================================
   // Constructors
@@ -99,6 +106,11 @@ class Parser :
     void addIp(const std::string&, const nmdo::IpAddress&);
     void addHwInfo(const std::string&, const std::string&, std::string&);
     void addCon(const std::string&, const std::string&, const nmdo::IpAddress&);
+
+    void updateIpAddrs();
+    void updateInterfaces();
+    void updateDeviceInformation();
+    void finalizeData();
 
     // Object return
     Result getData();

--- a/datastore/importers/nmdb-import-show-cdp-neighbor/Parser.hpp
+++ b/datastore/importers/nmdb-import-show-cdp-neighbor/Parser.hpp
@@ -59,6 +59,7 @@ class Parser :
   // Variables
   // ===========================================================================
   private:
+  protected:
     Data d;
 
     // Rules
@@ -68,7 +69,15 @@ class Parser :
     qi::rule<nmdp::IstreamIter, qi::ascii::blank_type>
       config,
       header,
+      deviceData,
+      ignoredLine,
       devIdAddr;
+
+    qi::rule<nmdp::IstreamIter>
+      hostnameValue,
+      ipAddressValue,
+      platformValue,
+      interfaceValue;
 
     qi::rule<nmdp::IstreamIter, std::string()>
       token;

--- a/datastore/importers/nmdb-import-show-cdp-neighbor/Parser.test.cpp
+++ b/datastore/importers/nmdb-import-show-cdp-neighbor/Parser.test.cpp
@@ -40,6 +40,8 @@ class TestParser : public Parser {
   public:
     using Parser::hostnameValue;
     using Parser::ipAddressValue;
+    using Parser::platformValue;
+    using Parser::interfaceValue;
 };
 BOOST_AUTO_TEST_CASE(testParts)
 {
@@ -83,8 +85,119 @@ BOOST_AUTO_TEST_CASE(testParts)
                 "Parse rule 'ipAddressValue': " << test);
     }
   }
+
+  {
+    const auto& parserRule {tp.platformValue};
+    std::vector<std::string> testsOk {
+      "Platform: Cisco 1234 (PID:1234-1234)-ABC\n",
+      "Platform: cisco 1234-1234\n",
+      "Platform: N5K-1234, Capabilities: Abc abc Abc-abc\n",
+      "Platform: cisco 1234, Capabilities:\n",
+    };
+    for (const auto& test : testsOk) {
+      BOOST_TEST(nmdp::test(test.c_str(), parserRule, blank),
+                "Parse rule 'platformValue': " << test);
+    }
+  }
+
+  {
+    const auto& parserRule {tp.interfaceValue};
+    std::vector<std::string> testsOk {
+      "Interface: gi1, Port ID (outgoing port): gi10\n",
+      "Interface: GigEth0/0, Port ID (outgoing port): GigEth10/10\n",
+    };
+    for (const auto& test : testsOk) {
+      BOOST_TEST(nmdp::test(test.c_str(), parserRule, blank),
+                "Parse rule 'platformValue': " << test);
+    }
+  }
 }
 
 BOOST_AUTO_TEST_CASE(testWhole)
 {
+  TestParser tp;
+
+  {
+    const auto& parserRule {tp};
+    std::vector<std::string> testsOk {
+      R"STR(
+---------------------------------------------
+Device-ID: a1234b4321
+Advertisement version: 2
+Platform: Cisco 1234-1234A (PID:A1234-1234A-A1234)-A
+Capabilities: Router Switch IGMP
+Interface: gi1, Port ID (outgoing port): gi10
+Holdtime: 100
+Version: 1.2.3.4
+Duplex: full
+Native VLAN: 1234
+SysName: ABC-1234-4312
+SysObjectID: 0.0
+Addresses:
+          IP 1.2.3.4
+      )STR",
+    };
+    for (const auto& test : testsOk) {
+      Result out;
+      BOOST_TEST(nmdp::testAttr(test.c_str(), parserRule, out, blank),
+                "Parse rule 'testWhole': " << test);
+      BOOST_TEST(1 == out.size());
+    }
+  }
+
+  {
+    const auto& parserRule {tp};
+    std::vector<std::string> testsOk {
+      R"STR(
+---------------------------------------------
+Device-ID: a1234b4321
+Advertisement version: 2
+Platform: Cisco 1234-1234A (PID:A1234-1234A-A1234)-A
+Capabilities: Router Switch IGMP
+Interface: gi1, Port ID (outgoing port): gi10
+Holdtime: 100
+Version: 1.2.3.4
+Duplex: full
+Native VLAN: 1234
+SysName: ABC-1234-4312
+SysObjectID: 0.0
+Addresses:
+          IP 1.2.3.4
+---------------------------------------------
+Device-ID: a1234b4321
+Advertisement version: 2
+Platform: Cisco 1234-1234A (PID:A1234-1234A-A1234)-A
+Capabilities: Router Switch IGMP
+Interface: gi1, Port ID (outgoing port): gi10
+Holdtime: 100
+Version: 1.2.3.4
+Duplex: full
+Native VLAN: 1234
+SysName: ABC-1234-4312
+SysObjectID: 0.0
+Addresses:
+          IP 1.2.3.4
+---------------------------------------------
+Device-ID: a1234b4321
+Advertisement version: 2
+Platform: Cisco 1234-1234A (PID:A1234-1234A-A1234)-A
+Capabilities: Router Switch IGMP
+Interface: gi1, Port ID (outgoing port): gi10
+Holdtime: 100
+Version: 1.2.3.4
+Duplex: full
+Native VLAN: 1234
+SysName: ABC-1234-4312
+SysObjectID: 0.0
+Addresses:
+          IP 1.2.3.4
+      )STR",
+    };
+    for (const auto& test : testsOk) {
+      Result out;
+      BOOST_TEST(nmdp::testAttr(test.c_str(), parserRule, out, blank),
+                "Parse rule 'testWhole': " << test);
+      BOOST_TEST(3 == out.size());
+    }
+  }
 }

--- a/datastore/importers/nmdb-import-show-cdp-neighbor/Parser.test.cpp
+++ b/datastore/importers/nmdb-import-show-cdp-neighbor/Parser.test.cpp
@@ -1,0 +1,90 @@
+// =============================================================================
+// Copyright 2017 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// =============================================================================
+// Maintained by Sandia National Laboratories <Netmeld@sandia.gov>
+// =============================================================================
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MAIN
+#include <boost/test/unit_test.hpp>
+
+#include <netmeld/datastore/parsers/ParserTestHelper.hpp>
+
+#include "Parser.hpp"
+
+namespace nmdp = netmeld::datastore::parsers;
+
+using qi::ascii::blank;
+
+class TestParser : public Parser {
+  public:
+    using Parser::hostnameValue;
+    using Parser::ipAddressValue;
+};
+BOOST_AUTO_TEST_CASE(testParts)
+{
+  TestParser tp;
+
+  {
+    const auto& parserRule {tp.hostnameValue};
+    std::vector<std::string> testsOk {
+      "Device-ID: hostname\n",
+      "Device ID: hostname\n",
+      "SysName: hostname\n",
+      "Device ID: hostname(hostname)\n",
+      "Device ID: hostname-hostname-hostname\n",
+      "Device ID: hostname.hostname-hostname\n",
+      "Device ID:hostname\n",
+    };
+    for (const auto& test : testsOk) {
+      BOOST_TEST(nmdp::test(test.c_str(), parserRule, blank),
+                "Parse rule 'hostnameValue': " << test);
+    }
+  }
+
+  {
+    const auto& parserRule {tp.ipAddressValue};
+    std::vector<std::string> testsOk {
+      "IP 1.2.3.4\n",
+      "IPv4 1.2.3.4\n",
+      "IPv6 1234::1234\n",
+      "IP address: 1.2.3.4\n",
+      "IPv4 address: 1.2.3.4\n",
+      "IPv6 address: 1234::1234\n",
+      "IP 1.2.3.4 (link-local)\n",
+      "IPv4 1.2.3.4 (link-local)\n",
+      "IPv6 1234::1234 (link-local)\n",
+      "IP address: 1.2.3.4 (link-local)\n",
+      "IPv4 address: 1.2.3.4 (link-local)\n",
+      "IPv6 address: 1234::1234 (link-local)\n",
+    };
+    for (const auto& test : testsOk) {
+      BOOST_TEST(nmdp::test(test.c_str(), parserRule, blank),
+                "Parse rule 'ipAddressValue': " << test);
+    }
+  }
+}
+
+BOOST_AUTO_TEST_CASE(testWhole)
+{
+}

--- a/datastore/importers/nmdb-import-show-cdp-neighbor/Parser.test.cpp
+++ b/datastore/importers/nmdb-import-show-cdp-neighbor/Parser.test.cpp
@@ -53,6 +53,7 @@ BOOST_AUTO_TEST_CASE(testParts)
       "Device-ID: hostname\n",
       "Device ID: hostname\n",
       "SysName: hostname\n",
+      "Device-ID: HOSTNAME\n",
       "Device ID: hostname(hostname)\n",
       "Device ID: hostname-hostname-hostname\n",
       "Device ID: hostname.hostname-hostname\n",


### PR DESCRIPTION
This PR resolves issues around being able to support multiple formats generated by the Cisco `show cdp neighbor detail` command.

---

While the majority of the supported formats can be seen in the new unit test, the primary focus was on format variations involving:
-  `Device-ID:` and `SysName:`
- `IP` and `IP address:`
- `Platform`