### PR TITLE
nmap parse logic for nbstat and smb-os-discovery

### DIFF
--- a/datastore/importers/nmdb-import-nmap/CMakeLists.txt
+++ b/datastore/importers/nmdb-import-nmap/CMakeLists.txt
@@ -25,11 +25,12 @@
 # =============================================================================
 
 add_executable(${TGT_TOOL}
+    ${TGT_TOOL}.cpp
+    NmapXmlParser.cpp
     NseResult.cpp
     SshAlgorithm.cpp
     SshPublicKey.cpp
     TracerouteHop.cpp
-    ${TGT_TOOL}.cpp
   )
 
 target_link_libraries(${TGT_TOOL}

--- a/datastore/importers/nmdb-import-nmap/CMakeLists.txt
+++ b/datastore/importers/nmdb-import-nmap/CMakeLists.txt
@@ -39,3 +39,22 @@ target_link_libraries(${TGT_TOOL}
   )
 
 nm_install_bin(${TGT_TOOL})
+
+foreach(ITEM
+    NmapXmlParser
+  )
+  nm_add_test(${ITEM})
+  target_sources(${TGT_TEST}
+    PRIVATE
+      NseResult.cpp
+      SshAlgorithm.cpp
+      SshPublicKey.cpp
+      TracerouteHop.cpp
+      ${ITEM}.hpp
+      ${ITEM}.cpp
+    )
+  target_link_libraries(${TGT_TEST}
+      netmeld-datastore
+      pugixml
+    )
+endforeach()

--- a/datastore/importers/nmdb-import-nmap/NmapXmlParser.cpp
+++ b/datastore/importers/nmdb-import-nmap/NmapXmlParser.cpp
@@ -1,0 +1,364 @@
+// =============================================================================
+// Copyright 2017 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// =============================================================================
+// Maintained by Sandia National Laboratories <Netmeld@sandia.gov>
+// =============================================================================
+
+#include "NmapXmlParser.hpp"
+#include <regex>
+
+NmapXmlParser::NmapXmlParser()
+{}
+
+std::tuple<std::string, std::string>
+NmapXmlParser::extractExecutionTiming(pugi::xml_node const& nmapNode)
+{
+  std::string start = nmapNode.attribute("start").as_string();
+  std::string stop  = nmapNode.select_node("runstats/finished")
+                      .node().attribute("time").as_string();
+
+  LOG_DEBUG << "[str] Start: " << start << std::endl;
+  LOG_DEBUG << "[str] Stop : " << stop << std::endl;
+
+  return std::make_tuple(start, stop);
+}
+
+bool
+NmapXmlParser::extractHostIsResponding(const pugi::xml_node& nodeHost) const
+{
+  bool isResponding = false;
+
+  pugi::xml_node const nodeStatus = nodeHost.child("status");
+
+  if (std::string("up") == nodeStatus.attribute("state").as_string()) {
+    if (std::string("user-set") !=
+        nodeStatus.attribute("reason").as_string()) {
+      // Any "up" reason other than "user-set" indicates
+      // that the host (or something else) responded.
+      isResponding = true;
+    }
+    else {  // "user-set" hosts:
+      if (0 < (nodeHost.select_nodes("ports/port/state"
+                           "[@state='open' or @state='closed']").size())) {
+        // The presence of "open" or "closed" ports indicates
+        // that the host (or something else) responded.
+        isResponding = true;
+      }
+    }
+  }
+
+  return isResponding;
+}
+
+nmdo::MacAddress
+NmapXmlParser::extractHostMacAddr(const pugi::xml_node& nodeHost) const
+{
+  pugi::xml_node const nodeMacAddr = nodeHost
+    .select_node("address[@addrtype='mac']")
+    .node();
+
+  std::string macString = nodeMacAddr.attribute("addr").as_string();
+
+  if (macString.empty()) {
+    return nmdo::MacAddress();
+  }
+
+  return nmdo::MacAddress(macString);
+}
+
+nmdo::IpAddress
+NmapXmlParser::extractHostIpAddr(const pugi::xml_node& nodeHost) const
+{
+  pugi::xml_node const nodeIpAddr = nodeHost
+    .select_node("address[@addrtype='ipv4' or @addrtype='ipv6']")
+    .node();
+
+  nmdo::IpAddress ipAddr;
+
+  std::string ipString = nodeIpAddr.attribute("addr").as_string();
+  if (!ipString.empty()) {
+    ipAddr.setAddress(ipString);
+  }
+
+  return ipAddr;
+}
+
+
+// =========================================================================
+// XML Parsing Functions
+// =========================================================================
+void
+NmapXmlParser::extractMacAndIpAddrs(const pugi::xml_node& nmapNode, Data& data)
+{ // This code block ensures that all of the ip_addrs and mac_addrs
+  // from the scan are present for the other table's foreign keys.
+  for (const auto& xHost : nmapNode.select_nodes("host")) {
+    pugi::xml_node nodeHost = xHost.node();
+
+    bool const isResponding = extractHostIsResponding(nodeHost);
+
+    nmdo::MacAddress macAddr = extractHostMacAddr(nodeHost);
+    macAddr.setResponding(isResponding);
+    auto ipAddr {extractHostIpAddr(nodeHost)};
+    macAddr.addIp(ipAddr);
+
+    data.macAddrs.push_back(macAddr);
+  }
+}
+
+void
+NmapXmlParser::extractHostnames(const pugi::xml_node& nmapNode, Data& data)
+{
+  for (const auto& xHostname :
+        nmapNode.select_nodes("host/hostnames/hostname")) {
+    pugi::xml_node nodeHostname = xHostname.node();
+    pugi::xml_node nodeHost = nodeHostname.parent().parent();
+
+    nmdo::IpAddress ipAddr = extractHostIpAddr(nodeHost);
+
+    ipAddr.addAlias(nodeHostname.attribute("name").as_string(),
+                    nodeHostname.attribute("type").as_string());
+
+    data.ipAddrs.push_back(ipAddr);
+  }
+
+  for (const auto& xScript :
+        nmapNode.select_nodes("host/hostscript/script")) {
+    pugi::xml_node nodeScript = xScript.node();
+    pugi::xml_node nodeHost   = nodeScript.parent().parent();
+
+    nmdo::IpAddress ipAddr = extractHostIpAddr(nodeHost);
+
+    std::string idValue {nodeScript.attribute("id").value()};
+    if (std::string("nbstat") == idValue) {
+      std::string reason  {"nmap nbstat"};
+      std::string line    {nodeScript.attribute("output").value()};
+      std::regex  regex   {"(NetBIOS name): ([^,]+),"};
+      std::smatch match;
+      while (std::regex_search(line, match, regex)) {
+        ipAddr.addAlias(std::string(match[2]), reason);
+        line = match.suffix();
+      }
+    } else if (std::string("smb-os-discovery") == idValue) {
+      std::string reason  {"nmap smb-os-discovery"};
+      std::string line    {nodeScript.attribute("output").value()};
+      std::regex  regex   {"(Computer name|FQDN): (.+?)\n"};
+      std::smatch match;
+      while (std::regex_search(line, match, regex)) {
+        ipAddr.addAlias(std::string(match[2]), reason);
+        line = match.suffix();
+      }
+    }
+
+    data.ipAddrs.push_back(ipAddr);
+  }
+}
+
+void
+NmapXmlParser::extractOperatingSystems(const pugi::xml_node& nmapNode, Data& data)
+{
+  for (const auto& xOsclass :
+         nmapNode.select_nodes("host/os/osmatch/osclass")) {
+    pugi::xml_node nodeOs = xOsclass.node();
+    pugi::xml_node nodeHost = nodeOs.parent().parent().parent();
+
+    nmdo::IpAddress ipAddr(extractHostIpAddr(nodeHost));
+    nmdo::OperatingSystem os(ipAddr);
+    os.setVendorName(nodeOs.attribute("vendor").as_string());
+    os.setProductName(nodeOs.attribute("osfamily").as_string());
+    os.setProductVersion(nodeOs.attribute("osgen").as_string());
+    os.setAccuracy(nodeOs.attribute("accuracy").as_double() / 100.0);
+    os.setCpe(nodeOs.select_node("cpe").node().text().as_string());
+
+    data.oses.push_back(os);
+  }
+}
+
+void
+NmapXmlParser::extractTraceRoutes(const pugi::xml_node& nmapNode, Data& data)
+{ // This code block identifies ip_addrs of routers along a route.
+  // The routers may or may not be in the target address space,
+  // so might need to be inserted into the ip_addrs table.
+  for (const auto& xHop : nmapNode.select_nodes("host/trace/hop")) {
+    pugi::xml_node nodeHop = xHop.node();
+
+    TracerouteHop hop;
+    hop.hopCount = nodeHop.attribute("ttl").as_int();
+
+    hop.rtrIpAddr = nmdo::IpAddress(nodeHop.attribute("ipaddr").as_string());
+    hop.rtrIpAddr.setResponding(true);
+
+    hop.dstIpAddr = extractHostIpAddr(nodeHop.parent().parent());
+
+    data.tracerouteHops.push_back(hop);
+  }
+}
+
+void
+NmapXmlParser::extractPortsAndServices(const pugi::xml_node& nmapNode, Data& data)
+{
+  for (const auto& xExtrareasons :
+         nmapNode.select_nodes("host/ports/extraports/extrareasons")) {
+    pugi::xml_node nodeExtrareasons = xExtrareasons.node();
+    pugi::xml_node nodeExtraports = nodeExtrareasons.parent();
+    pugi::xml_node nodeHost = nodeExtraports.parent().parent();
+
+    nmdo::IpAddress ipAddr = extractHostIpAddr(nodeHost);
+    nmdo::Port port(ipAddr);
+    port.setPort(-1);
+    port.setState(nodeExtraports.attribute("state").as_string());
+
+    std::string portReason =
+      nodeExtrareasons.attribute("reason").as_string();
+    port.setReason(portReason);
+
+    std::string protocol;
+    if (1 == nmapNode.select_nodes("scaninfo").size()) {
+      // If there is only a single scaninfo element,
+      // all extraports protocols must be the scaninfo's protocol.
+      protocol = nmapNode.select_node("scaninfo")
+                  .node().attribute("protocol").as_string();
+    }
+    else if (  (portReason == "tcp-response")
+            || (portReason == "tcp-responses")
+            || (portReason == "syn-ack")
+            || (portReason == "syn-acks")
+            || (portReason == "reset")
+            || (portReason == "resets")) {
+      // If there are multiple scaninfo elements
+      // (meaning the scan was a multi-protocol scan),
+      // certain port_reason values indicate or imply TCP.
+      protocol = "tcp";
+    }
+    else if (  (portReason == "udp-response")
+            || (portReason == "udp-responses")
+            || (portReason == "port-unreach")
+            || (portReason == "port-unreaches")) {
+      // If there are multiple scaninfo elements
+      // (meaning the scan was a multi-protocol scan),
+      // certain port_reason values indicate or imply UDP.
+      protocol = "udp";
+    }
+
+    port.setProtocol(protocol);
+
+    data.ports.push_back(port);
+  }
+
+  for (const auto& xPort : nmapNode.select_nodes("host/ports/port")) {
+    pugi::xml_node nodePort = xPort.node();
+    pugi::xml_node nodePortState = nodePort.child("state");
+    pugi::xml_node nodeHost = nodePort.parent().parent();
+
+    nmdo::IpAddress ipAddr = extractHostIpAddr(nodeHost);
+    nmdo::Port port(ipAddr);
+
+    std::string protocol = nodePort.attribute("protocol").as_string();
+    port.setProtocol(protocol);
+
+    int portNum = nodePort.attribute("portid").as_int();
+    port.setPort(portNum);
+
+    port.setState(nodePortState.attribute("state").as_string());
+    port.setReason(nodePortState.attribute("reason").as_string());
+
+    data.ports.push_back(port);
+
+    pugi::xml_node nodeService = nodePort.child("service");
+    if (nodeService) {
+      nmdo::Service service(nodeService.attribute("name").as_string(),
+                           ipAddr);
+      service.setProtocol(protocol);
+
+      std::string portStr = std::to_string(portNum);
+      service.addDstPort(portStr);
+
+      service.setServiceDescription(
+          nodeService.attribute("product").as_string());
+      service.setServiceReason(nodeService.attribute("method").as_string());
+
+      data.services.push_back(service);
+    }
+  }
+}
+
+void
+NmapXmlParser::extractNseAndSsh(const pugi::xml_node& nmapNode, Data& data)
+{
+  for (const auto& xScript :
+         nmapNode.select_nodes("host/ports/port/script")) {
+    pugi::xml_node nodeScript = xScript.node();
+    pugi::xml_node nodePort = nodeScript.parent();
+    pugi::xml_node nodeHost = nodePort.parent().parent();
+
+    nmdo::IpAddress ipAddr(extractHostIpAddr(nodeHost));
+
+    NseResult nse;
+    nse.port = nmdo::Port(ipAddr);
+    nse.port.setProtocol(nodePort.attribute("protocol").as_string());
+    nse.port.setPort(nodePort.attribute("portid").as_int());
+    nse.scriptId = nodeScript.attribute("id").as_string();
+    nse.scriptOutput = nodeScript.attribute("output").as_string();
+
+    data.nseResults.push_back(nse);
+
+    if (nse.scriptId == "ssh-hostkey") {
+      for (const auto& xTable : nodeScript.select_nodes("table")) {
+        pugi::xml_node nodeTable = xTable.node();
+
+        SshPublicKey key;
+        key.port = nse.port;
+
+        key.type = nodeTable.select_node("elem[@key='type']")
+          .node().text().as_string();
+
+        key.bits = nodeTable.select_node("elem[@key='bits']")
+          .node().text().as_int();
+
+        key.fingerprint =
+          nodeTable.select_node("elem[@key='fingerprint']")
+            .node().text().as_string();
+
+        key.key = nodeTable.select_node("elem[@key='key']")
+          .node().text().as_string();
+
+        data.sshKeys.push_back(key);
+      }
+    }
+    else if (nse.scriptId == "ssh2-enum-algos") {
+      for (const auto& xTable : nodeScript.select_nodes("table")) {
+        pugi::xml_node nodeTable = xTable.node();
+
+        for (const auto& xElem : nodeTable.select_nodes("elem")) {
+          pugi::xml_node nodeElem = xElem.node();
+
+          SshAlgorithm algo;
+          algo.port = nse.port;
+          algo.type = nodeTable.attribute("key").as_string();
+          algo.name = nodeElem.text().as_string();
+
+          data.sshAlgorithms.push_back(algo);
+        }
+      }
+    }
+  }
+}

--- a/datastore/importers/nmdb-import-nmap/NmapXmlParser.cpp
+++ b/datastore/importers/nmdb-import-nmap/NmapXmlParser.cpp
@@ -134,9 +134,10 @@ NmapXmlParser::extractHostnames(const pugi::xml_node& nmapNode, Data& data)
     pugi::xml_node nodeHost = nodeHostname.parent().parent();
 
     nmdo::IpAddress ipAddr = extractHostIpAddr(nodeHost);
-
-    ipAddr.addAlias(nodeHostname.attribute("name").as_string(),
-                    nodeHostname.attribute("type").as_string());
+    
+    std::string reason {"nmap "};
+    reason.append(nodeHostname.attribute("type").as_string());
+    ipAddr.addAlias(nodeHostname.attribute("name").as_string(), reason);
 
     data.ipAddrs.push_back(ipAddr);
   }

--- a/datastore/importers/nmdb-import-nmap/NmapXmlParser.cpp
+++ b/datastore/importers/nmdb-import-nmap/NmapXmlParser.cpp
@@ -150,24 +150,20 @@ NmapXmlParser::extractHostnames(const pugi::xml_node& nmapNode, Data& data)
     nmdo::IpAddress ipAddr = extractHostIpAddr(nodeHost);
 
     std::string idValue {nodeScript.attribute("id").value()};
+    std::string reason  {"nmap " + idValue};
+    std::string line    {nodeScript.attribute("output").value()};
+    std::regex  regex;
+    std::smatch match;
+
     if (std::string("nbstat") == idValue) {
-      std::string reason  {"nmap nbstat"};
-      std::string line    {nodeScript.attribute("output").value()};
-      std::regex  regex   {"(NetBIOS name): ([^,]+),"};
-      std::smatch match;
-      while (std::regex_search(line, match, regex)) {
-        ipAddr.addAlias(std::string(match[2]), reason);
-        line = match.suffix();
-      }
+      regex = "(NetBIOS name): ([^,]+),";
     } else if (std::string("smb-os-discovery") == idValue) {
-      std::string reason  {"nmap smb-os-discovery"};
-      std::string line    {nodeScript.attribute("output").value()};
-      std::regex  regex   {"(Computer name|FQDN): (.+?)\n"};
-      std::smatch match;
-      while (std::regex_search(line, match, regex)) {
-        ipAddr.addAlias(std::string(match[2]), reason);
-        line = match.suffix();
-      }
+      regex = "(Computer name|FQDN): (.+?)\n";
+    }
+
+    while (std::regex_search(line, match, regex)) {
+      ipAddr.addAlias(std::string(match[2]), reason);
+      line = match.suffix();
     }
 
     data.ipAddrs.push_back(ipAddr);

--- a/datastore/importers/nmdb-import-nmap/NmapXmlParser.hpp
+++ b/datastore/importers/nmdb-import-nmap/NmapXmlParser.hpp
@@ -1,0 +1,109 @@
+// =============================================================================
+// Copyright 2017 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// =============================================================================
+// Maintained by Sandia National Laboratories <Netmeld@sandia.gov>
+// =============================================================================
+
+#ifndef NMAP_XML_PARSER_HPP
+#define NMAP_XML_PARSER_HPP
+
+#include <pugixml.hpp>
+
+#include <netmeld/datastore/objects/IpAddress.hpp>
+#include <netmeld/datastore/objects/MacAddress.hpp>
+#include <netmeld/datastore/objects/OperatingSystem.hpp>
+#include <netmeld/datastore/objects/Port.hpp>
+#include <netmeld/datastore/objects/Service.hpp>
+#include <netmeld/datastore/parsers/ParserHelper.hpp>
+#include <netmeld/datastore/tools/AbstractImportTool.hpp>
+
+#include "NseResult.hpp"
+#include "SshAlgorithm.hpp"
+#include "SshPublicKey.hpp"
+#include "TracerouteHop.hpp"
+
+namespace nmdo = netmeld::datastore::objects;
+namespace nmdp = netmeld::datastore::parsers;
+namespace nmdt = netmeld::datastore::tools;
+namespace nmdu = netmeld::datastore::utils;
+
+// =============================================================================
+// Data containers
+// =============================================================================
+struct Data
+{
+  std::vector<nmdo::MacAddress>       macAddrs;
+  std::vector<nmdo::IpAddress>        ipAddrs;
+  std::vector<nmdo::OperatingSystem>  oses;
+  std::vector<TracerouteHop>          tracerouteHops;
+  std::vector<nmdo::Port>             ports;
+  std::vector<nmdo::Service>          services;
+  std::vector<NseResult>              nseResults;
+  std::vector<SshPublicKey>           sshKeys;
+  std::vector<SshAlgorithm>           sshAlgorithms;
+};
+typedef std::vector<Data>  Result;
+
+
+// =============================================================================
+// Parser definition
+// =============================================================================
+class NmapXmlParser
+{
+  // ===========================================================================
+  // Variables
+  // ===========================================================================
+  private:
+  protected:
+  public:
+
+  // ===========================================================================
+  // Constructors
+  // ===========================================================================
+  private:
+  protected:
+  public:
+    NmapXmlParser();
+
+  // ===========================================================================
+  // Methods
+  // ===========================================================================
+  private:
+  protected:
+    bool extractHostIsResponding(const pugi::xml_node&) const;
+    nmdo::MacAddress extractHostMacAddr(const pugi::xml_node&) const;
+    nmdo::IpAddress extractHostIpAddr(const pugi::xml_node&) const;
+
+  public:
+    std::tuple<std::string, std::string>
+      extractExecutionTiming(const pugi::xml_node&);
+
+    void extractMacAndIpAddrs(const pugi::xml_node&, Data&);
+    void extractHostnames(const pugi::xml_node&, Data&);
+    void extractOperatingSystems(const pugi::xml_node&, Data&);
+    void extractTraceRoutes(const pugi::xml_node&, Data&);
+    void extractPortsAndServices(const pugi::xml_node&, Data&);
+    void extractNseAndSsh(const pugi::xml_node&, Data&);
+};
+
+#endif //NMAP_XML_PARSER_HPP

--- a/datastore/importers/nmdb-import-nmap/NmapXmlParser.test.cpp
+++ b/datastore/importers/nmdb-import-nmap/NmapXmlParser.test.cpp
@@ -1,0 +1,144 @@
+// =============================================================================
+// Copyright 2017 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// =============================================================================
+// Maintained by Sandia National Laboratories <Netmeld@sandia.gov>
+// =============================================================================
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MAIN
+#include <boost/test/unit_test.hpp>
+
+#include <pugixml.hpp>
+
+#include <netmeld/datastore/parsers/ParserTestHelper.hpp>
+
+#include "NmapXmlParser.hpp"
+
+class TestNmapXmlParser : public NmapXmlParser
+{
+  public:
+    using NmapXmlParser::extractHostIsResponding;
+    using NmapXmlParser::extractHostMacAddr;
+    using NmapXmlParser::extractHostIpAddr;
+};
+// For reference, the XML schema is: https://nmap.org/book/nmap-dtd.html
+
+BOOST_AUTO_TEST_CASE(testExtractHostnames)
+{
+  TestNmapXmlParser tnxp;
+
+  {
+    pugi::xml_document doc;
+
+    Data d;
+    doc.load_string(
+      R"STR(
+      <host starttime="1234567890" endtime="1234567899">
+      <address addr="1.2.3.4" addrtype="ipv4"/>
+      <address addr="00:11:22:33:44:55" addrtype="mac" vendor="NO-ONE"/>
+      <hostnames>                                                                     
+      <hostname name="some_host" type="user"/>                                           
+      <hostname name="some_host" type="PTR"/>                                            
+      </hostnames> 
+      </host>
+      )STR");
+    const pugi::xml_node testNode {doc.document_element().root()};
+    tnxp.extractHostnames(testNode, d);
+
+    BOOST_TEST(2 == d.ipAddrs.size());
+    for (const auto& ipa : d.ipAddrs) {
+      BOOST_TEST("1.2.3.4/32" == ipa.toString());
+      const auto aliases {ipa.getAliases()};
+      BOOST_TEST(1 == aliases.size());
+      BOOST_TEST(1 == aliases.count("some_host"));
+    }
+    BOOST_TEST("[1.2.3.4/32, 0, nmap user, 0, [some_host], ]"
+               == d.ipAddrs[0].toDebugString());
+    BOOST_TEST("[1.2.3.4/32, 0, nmap ptr, 0, [some_host], ]"
+               == d.ipAddrs[1].toDebugString());
+  }
+
+  {
+    pugi::xml_document doc;
+
+    Data d;
+    doc.load_string(
+      R"STR(
+      <host starttime="1234567890" endtime="1234567899">
+      <address addr="1.2.3.4" addrtype="ipv4"/>
+      <address addr="00:11:22:33:44:55" addrtype="mac" vendor="NO-ONE"/>
+      <hostscript>
+      <script id="nbstat" output="NetBIOS name: some_host, NetBIOS user: &lt;unknown&gt;, NetBIOS MAC: 00:11:22:33:44:55 (NO-ONE)"/>
+      </hostscript>
+      </host>
+      )STR");
+    const pugi::xml_node testNode {doc.document_element().root()};
+    tnxp.extractHostnames(testNode, d);
+
+    BOOST_TEST(1 == d.ipAddrs.size());
+    const auto ipa {d.ipAddrs[0]};
+    BOOST_TEST("1.2.3.4/32" == ipa.toString());
+    const auto aliases {ipa.getAliases()};
+    BOOST_TEST(1 == aliases.size());
+    BOOST_TEST(1 == aliases.count("some_host"));
+    BOOST_TEST("[1.2.3.4/32, 0, nmap nbstat, 0, [some_host], ]"
+               == ipa.toDebugString());
+  }
+
+  {
+    pugi::xml_document doc;
+
+    Data d;
+    doc.load_string(
+      R"STR(
+      <host starttime="1234567890" endtime="1234567899">
+      <address addr="1.2.3.4" addrtype="ipv4"/>
+      <address addr="00:11:22:33:44:55" addrtype="mac" vendor="NO-ONE"/>
+      <hostscript>
+      <script id="smb-os-discovery" output="&#xa;  OS: Some OS (SomeOsFlavor 1.2.3)&#xa;  OS CPE: cpe:/o:some_vendor:some_os:::&#xa;  Computer name: some_host&#xa;  NetBIOS computer name: SOME_HOST\x00&#xa;  Domain name: some_domain.some_forest&#xa;  Forest name: some_forest&#xa;  FQDN: some_host.some_domain.some_forest&#xa;  System time: 2000-01-01T00:00:01+00:00&#xa;">
+      <elem key="os">Some OS</elem>
+      <elem key="lanmanager">SomeOsFlavor 1.2.3</elem>
+      <elem key="server">SOME_HOST\x00</elem>
+      <elem key="date">2000-01-01T00:00:01+00:00</elem>
+      <elem key="fqdn">some_host.some_domain.some_forest</elem>
+      <elem key="domain_dns">some_domain.some_forest</elem>
+      <elem key="forest_dns">some_forest</elem>
+      <elem key="workgroup">SOME_WORKGROUP\x00</elem>
+      <elem key="cpe">cpe:/o:::::</elem>
+      </hostscript>
+      </host>
+      )STR");
+    const pugi::xml_node testNode {doc.document_element().root()};
+    tnxp.extractHostnames(testNode, d);
+
+    BOOST_TEST(1 == d.ipAddrs.size());
+    const auto ipa {d.ipAddrs[0]};
+    BOOST_TEST("1.2.3.4/32" == ipa.toString());
+    const auto aliases {ipa.getAliases()};
+    BOOST_TEST(2 == aliases.size());
+    BOOST_TEST(1 == aliases.count("some_host"));
+    BOOST_TEST(1 == aliases.count("some_host.some_domain.some_forest"));
+    BOOST_TEST("[1.2.3.4/32, 0, nmap smb-os-discovery, 0, [some_host, some_host.some_domain.some_forest], ]"
+               == ipa.toDebugString());
+  }
+}

--- a/datastore/importers/nmdb-import-nmap/nmdb-import-nmap.cpp
+++ b/datastore/importers/nmdb-import-nmap/nmdb-import-nmap.cpp
@@ -29,10 +29,6 @@
 #include <pugixml.hpp>
 
 #include <netmeld/datastore/objects/IpAddress.hpp>
-//#include <netmeld/datastore/objects/MacAddress.hpp>
-//#include <netmeld/datastore/objects/OperatingSystem.hpp>
-//#include <netmeld/datastore/objects/Port.hpp>
-//#include <netmeld/datastore/objects/Service.hpp>
 #include <netmeld/datastore/parsers/ParserHelper.hpp>
 #include <netmeld/datastore/tools/AbstractImportTool.hpp>
 

--- a/datastore/importers/nmdb-import-nmap/nmdb-import-nmap.cpp
+++ b/datastore/importers/nmdb-import-nmap/nmdb-import-nmap.cpp
@@ -29,36 +29,19 @@
 #include <pugixml.hpp>
 
 #include <netmeld/datastore/objects/IpAddress.hpp>
-#include <netmeld/datastore/objects/MacAddress.hpp>
-#include <netmeld/datastore/objects/OperatingSystem.hpp>
-#include <netmeld/datastore/objects/Port.hpp>
-#include <netmeld/datastore/objects/Service.hpp>
+//#include <netmeld/datastore/objects/MacAddress.hpp>
+//#include <netmeld/datastore/objects/OperatingSystem.hpp>
+//#include <netmeld/datastore/objects/Port.hpp>
+//#include <netmeld/datastore/objects/Service.hpp>
 #include <netmeld/datastore/parsers/ParserHelper.hpp>
 #include <netmeld/datastore/tools/AbstractImportTool.hpp>
 
-#include "NseResult.hpp"
-#include "SshAlgorithm.hpp"
-#include "SshPublicKey.hpp"
-#include "TracerouteHop.hpp"
+#include "NmapXmlParser.hpp"
 
 namespace nmdo = netmeld::datastore::objects;
 namespace nmdp = netmeld::datastore::parsers;
 namespace nmdt = netmeld::datastore::tools;
 namespace nmdu = netmeld::datastore::utils;
-
-struct Data
-{
-  std::vector<nmdo::MacAddress>       macAddrs;
-  std::vector<nmdo::IpAddress>        ipAddrs;
-  std::vector<nmdo::OperatingSystem>  oses;
-  std::vector<TracerouteHop>          tracerouteHops;
-  std::vector<nmdo::Port>             ports;
-  std::vector<nmdo::Service>          services;
-  std::vector<NseResult>              nseResults;
-  std::vector<SshPublicKey>           sshKeys;
-  std::vector<SshAlgorithm>           sshAlgorithms;
-};
-typedef std::vector<Data>  Results;
 
 
 template<typename P, typename R>
@@ -107,16 +90,24 @@ class Tool : public nmdt::AbstractImportTool<P,R>
         std::exit(nmcu::Exit::FAILURE);
       }
 
-      extractExecutionTiming(nmapNode);
+      NmapXmlParser nxp;
+
+      auto t {nxp.extractExecutionTiming(nmapNode)};
+
+      this->executionStart.readUnixTimestamp(std::get<0>(t));
+      this->executionStop.readUnixTimestamp(std::get<1>(t));
+
+      LOG_DEBUG << "[nmco] Start: " << this->executionStart << std::endl;
+      LOG_DEBUG << "[nmco] Stop : " << this->executionStop << std::endl;
 
       Data data;
 
-      extractMacAndIpAddrs(nmapNode, data);
-      extractHostnames(nmapNode, data);
-      extractOperatingSystems(nmapNode, data);
-      extractTraceRoutes(nmapNode, data);
-      extractPortsAndServices(nmapNode, data);
-      extractNseAndSsh(nmapNode, data);
+      nxp.extractMacAndIpAddrs(nmapNode, data);
+      nxp.extractHostnames(nmapNode, data);
+      nxp.extractOperatingSystems(nmapNode, data);
+      nxp.extractTraceRoutes(nmapNode, data);
+      nxp.extractPortsAndServices(nmapNode, data);
+      nxp.extractNseAndSsh(nmapNode, data);
 
       this->tResults.push_back(data);
     }
@@ -189,354 +180,12 @@ class Tool : public nmdt::AbstractImportTool<P,R>
     }
 
   private:
-    // =========================================================================
-    // Supporting Functions
-    // =========================================================================
-    void
-    extractExecutionTiming(pugi::xml_node const& nmapNode)
-    {
-      std::string start = nmapNode.attribute("start").as_string();
-      std::string stop  = nmapNode.select_node("runstats/finished")
-                          .node().attribute("time").as_string();
-
-      LOG_DEBUG << "[str] Start: " << start << std::endl;
-      LOG_DEBUG << "[str] Stop : " << stop << std::endl;
-
-      this->executionStart.readUnixTimestamp(start);
-      this->executionStop.readUnixTimestamp(stop);
-
-      LOG_DEBUG << "[nmco] Start: " << this->executionStart << std::endl;
-      LOG_DEBUG << "[nmco] Stop : " << this->executionStop << std::endl;
-    }
-
-    bool
-    extractHostIsResponding(pugi::xml_node const& nodeHost) const
-    {
-      bool isResponding = false;
-
-      pugi::xml_node const nodeStatus = nodeHost.child("status");
-
-      if (std::string("up") == nodeStatus.attribute("state").as_string()) {
-        if (std::string("user-set") !=
-            nodeStatus.attribute("reason").as_string()) {
-          // Any "up" reason other than "user-set" indicates
-          // that the host (or something else) responded.
-          isResponding = true;
-        }
-        else {  // "user-set" hosts:
-          if (0 < (nodeHost.select_nodes("ports/port/state"
-                               "[@state='open' or @state='closed']").size())) {
-            // The presence of "open" or "closed" ports indicates
-            // that the host (or something else) responded.
-            isResponding = true;
-          }
-        }
-      }
-
-      return isResponding;
-    }
-
-    nmdo::MacAddress
-    extractHostMacAddr(pugi::xml_node const& nodeHost) const
-    {
-      pugi::xml_node const nodeMacAddr = nodeHost
-        .select_node("address[@addrtype='mac']")
-        .node();
-
-      std::string macString = nodeMacAddr.attribute("addr").as_string();
-
-      if (macString.empty()) {
-        return nmdo::MacAddress();
-      }
-
-      return nmdo::MacAddress(macString);
-    }
-
-    nmdo::IpAddress
-    extractHostIpAddr(pugi::xml_node const& nodeHost) const
-    {
-      pugi::xml_node const nodeIpAddr = nodeHost
-        .select_node("address[@addrtype='ipv4' or @addrtype='ipv6']")
-        .node();
-
-      nmdo::IpAddress ipAddr;
-
-      std::string ipString = nodeIpAddr.attribute("addr").as_string();
-      if (!ipString.empty()) {
-        ipAddr.setAddress(ipString);
-      }
-
-      return ipAddr;
-    }
-
-
-    // =========================================================================
-    // XML Parsing Functions
-    // =========================================================================
-    void
-    extractMacAndIpAddrs(pugi::xml_node nmapNode, Data& data)
-    { // This code block ensures that all of the ip_addrs and mac_addrs
-      // from the scan are present for the other table's foreign keys.
-      for (const auto& xHost : nmapNode.select_nodes("host")) {
-        pugi::xml_node nodeHost = xHost.node();
-
-        bool const isResponding = extractHostIsResponding(nodeHost);
-
-        nmdo::MacAddress macAddr = extractHostMacAddr(nodeHost);
-        macAddr.setResponding(isResponding);
-        auto ipAddr {extractHostIpAddr(nodeHost)};
-        macAddr.addIp(ipAddr);
-
-        data.macAddrs.push_back(macAddr);
-      }
-    }
-
-    void
-    extractHostnames(pugi::xml_node nmapNode, Data& data)
-    {
-      for (const auto& xHostname :
-            nmapNode.select_nodes("host/hostnames/hostname")) {
-        pugi::xml_node nodeHostname = xHostname.node();
-        pugi::xml_node nodeHost = nodeHostname.parent().parent();
-
-        nmdo::IpAddress ipAddr = extractHostIpAddr(nodeHost);
-
-        ipAddr.addAlias(nodeHostname.attribute("name").as_string(),
-                        nodeHostname.attribute("type").as_string());
-
-        data.ipAddrs.push_back(ipAddr);
-      }
-
-      std::string target {"host/hostscript/script"};
-      LOG_INFO << "Looking for: " << target << '\n';
-      for (const auto& xHostname : nmapNode.select_nodes(target.c_str())) {
-        pugi::xml_node nodeHost = xHostname.node().parent().parent();
-        nmdo::IpAddress ipAddr = extractHostIpAddr(nodeHost);
-
-        pugi::xml_node xNode = xHostname.node();
-
-        std::string idValue {xNode.attribute("id").value()};
-        if (std::string("nbstat") == idValue) {
-          std::string line  {xNode.attribute("output").value()};
-          std::regex  regex {"(NetBIOS name): ([^,]+),"};
-          std::smatch match;
-          while (std::regex_search(line, match, regex)) {
-            LOG_INFO << match[1] << ": " << match[2] << '\n';
-            ipAddr.addAlias(std::string(match[2]), "nmap nbstat");
-            line = match.suffix();
-          }
-        }
-        if (std::string("smb-os-discovery") == idValue) {
-          std::string line  {xNode.attribute("output").value()};
-          std::regex  regex {"(Computer name|FQDN): (.+?)\n"};
-          std::smatch match;
-          while (std::regex_search(line, match, regex)) {
-            LOG_INFO << match[1] << ": " << match[2] << '\n';
-            ipAddr.addAlias(std::string(match[2]), "nmap smb-os-discovery");
-            line = match.suffix();
-          }
-        }
-
-        data.ipAddrs.push_back(ipAddr);
-      }
-    }
-
-    void
-    extractOperatingSystems(pugi::xml_node nmapNode, Data& data)
-    {
-      for (const auto& xOsclass :
-             nmapNode.select_nodes("host/os/osmatch/osclass")) {
-        pugi::xml_node nodeOs = xOsclass.node();
-        pugi::xml_node nodeHost = nodeOs.parent().parent().parent();
-
-        nmdo::IpAddress ipAddr(extractHostIpAddr(nodeHost));
-        nmdo::OperatingSystem os(ipAddr);
-        os.setVendorName(nodeOs.attribute("vendor").as_string());
-        os.setProductName(nodeOs.attribute("osfamily").as_string());
-        os.setProductVersion(nodeOs.attribute("osgen").as_string());
-        os.setAccuracy(nodeOs.attribute("accuracy").as_double() / 100.0);
-        os.setCpe(nodeOs.select_node("cpe").node().text().as_string());
-
-        data.oses.push_back(os);
-      }
-    }
-
-    void
-    extractTraceRoutes(pugi::xml_node nmapNode, Data& data)
-    { // This code block identifies ip_addrs of routers along a route.
-      // The routers may or may not be in the target address space,
-      // so might need to be inserted into the ip_addrs table.
-      for (const auto& xHop : nmapNode.select_nodes("host/trace/hop")) {
-        pugi::xml_node nodeHop = xHop.node();
-
-        TracerouteHop hop;
-        hop.hopCount = nodeHop.attribute("ttl").as_int();
-
-        hop.rtrIpAddr = nmdo::IpAddress(nodeHop.attribute("ipaddr").as_string());
-        hop.rtrIpAddr.setResponding(true);
-
-        hop.dstIpAddr = extractHostIpAddr(nodeHop.parent().parent());
-
-        data.tracerouteHops.push_back(hop);
-      }
-    }
-
-    void
-    extractPortsAndServices(pugi::xml_node nmapNode, Data& data)
-    {
-      for (const auto& xExtrareasons :
-             nmapNode.select_nodes("host/ports/extraports/extrareasons")) {
-        pugi::xml_node nodeExtrareasons = xExtrareasons.node();
-        pugi::xml_node nodeExtraports = nodeExtrareasons.parent();
-        pugi::xml_node nodeHost = nodeExtraports.parent().parent();
-
-        nmdo::IpAddress ipAddr = extractHostIpAddr(nodeHost);
-        nmdo::Port port(ipAddr);
-        port.setPort(-1);
-        port.setState(nodeExtraports.attribute("state").as_string());
-
-        std::string portReason =
-          nodeExtrareasons.attribute("reason").as_string();
-        port.setReason(portReason);
-
-        std::string protocol;
-        if (1 == nmapNode.select_nodes("scaninfo").size()) {
-          // If there is only a single scaninfo element,
-          // all extraports protocols must be the scaninfo's protocol.
-          protocol = nmapNode.select_node("scaninfo")
-                      .node().attribute("protocol").as_string();
-        }
-        else if (  (portReason == "tcp-response")
-                || (portReason == "tcp-responses")
-                || (portReason == "syn-ack")
-                || (portReason == "syn-acks")
-                || (portReason == "reset")
-                || (portReason == "resets")) {
-          // If there are multiple scaninfo elements
-          // (meaning the scan was a multi-protocol scan),
-          // certain port_reason values indicate or imply TCP.
-          protocol = "tcp";
-        }
-        else if (  (portReason == "udp-response")
-                || (portReason == "udp-responses")
-                || (portReason == "port-unreach")
-                || (portReason == "port-unreaches")) {
-          // If there are multiple scaninfo elements
-          // (meaning the scan was a multi-protocol scan),
-          // certain port_reason values indicate or imply UDP.
-          protocol = "udp";
-        }
-
-        port.setProtocol(protocol);
-
-        data.ports.push_back(port);
-      }
-
-      for (const auto& xPort : nmapNode.select_nodes("host/ports/port")) {
-        pugi::xml_node nodePort = xPort.node();
-        pugi::xml_node nodePortState = nodePort.child("state");
-        pugi::xml_node nodeHost = nodePort.parent().parent();
-
-        nmdo::IpAddress ipAddr = extractHostIpAddr(nodeHost);
-        nmdo::Port port(ipAddr);
-
-        std::string protocol = nodePort.attribute("protocol").as_string();
-        port.setProtocol(protocol);
-
-        int portNum = nodePort.attribute("portid").as_int();
-        port.setPort(portNum);
-
-        port.setState(nodePortState.attribute("state").as_string());
-        port.setReason(nodePortState.attribute("reason").as_string());
-
-        data.ports.push_back(port);
-
-        pugi::xml_node nodeService = nodePort.child("service");
-        if (nodeService) {
-          nmdo::Service service(nodeService.attribute("name").as_string(),
-                               ipAddr);
-          service.setProtocol(protocol);
-
-          std::string portStr = std::to_string(portNum);
-          service.addDstPort(portStr);
-
-          service.setServiceDescription(
-              nodeService.attribute("product").as_string());
-          service.setServiceReason(nodeService.attribute("method").as_string());
-
-          data.services.push_back(service);
-        }
-      }
-    }
-
-    void
-    extractNseAndSsh(pugi::xml_node nmapNode, Data& data)
-    {
-      for (const auto& xScript :
-             nmapNode.select_nodes("host/ports/port/script")) {
-        pugi::xml_node nodeScript = xScript.node();
-        pugi::xml_node nodePort = nodeScript.parent();
-        pugi::xml_node nodeHost = nodePort.parent().parent();
-
-        nmdo::IpAddress ipAddr(extractHostIpAddr(nodeHost));
-
-        NseResult nse;
-        nse.port = nmdo::Port(ipAddr);
-        nse.port.setProtocol(nodePort.attribute("protocol").as_string());
-        nse.port.setPort(nodePort.attribute("portid").as_int());
-        nse.scriptId = nodeScript.attribute("id").as_string();
-        nse.scriptOutput = nodeScript.attribute("output").as_string();
-
-        data.nseResults.push_back(nse);
-
-        if (nse.scriptId == "ssh-hostkey") {
-          for (const auto& xTable : nodeScript.select_nodes("table")) {
-            pugi::xml_node nodeTable = xTable.node();
-
-            SshPublicKey key;
-            key.port = nse.port;
-
-            key.type = nodeTable.select_node("elem[@key='type']")
-              .node().text().as_string();
-
-            key.bits = nodeTable.select_node("elem[@key='bits']")
-              .node().text().as_int();
-
-            key.fingerprint =
-              nodeTable.select_node("elem[@key='fingerprint']")
-                .node().text().as_string();
-
-            key.key = nodeTable.select_node("elem[@key='key']")
-              .node().text().as_string();
-
-            data.sshKeys.push_back(key);
-          }
-        }
-        else if (nse.scriptId == "ssh2-enum-algos") {
-          for (const auto& xTable : nodeScript.select_nodes("table")) {
-            pugi::xml_node nodeTable = xTable.node();
-
-            for (const auto& xElem : nodeTable.select_nodes("elem")) {
-              pugi::xml_node nodeElem = xElem.node();
-
-              SshAlgorithm algo;
-              algo.port = nse.port;
-              algo.type = nodeTable.attribute("key").as_string();
-              algo.name = nodeElem.text().as_string();
-
-              data.sshAlgorithms.push_back(algo);
-            }
-          }
-        }
-      }
-    }
 };
 
 
 int
 main(int argc, char** argv)
 {
-  Tool<nmdp::DummyParser, Results> tool;
+  Tool<nmdp::DummyParser, Result> tool;
   return tool.start(argc, argv);
 }
-


### PR DESCRIPTION
This PR closes #41.

---

Specifically, it adds parse logic support to the nmap hostscripts:
- nbstat
- smb-os-discovery