### PR TITLE
Add manual docker build trigger

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -12,6 +12,8 @@ on:
 
 jobs:
   docker:
+    if: github.repository == 'netmeld/netmeld'
+
     runs-on: ubuntu-latest
     
     steps:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,9 +1,14 @@
 name: DockerBuild
 
-#on: push
 on:
   schedule:
     - cron: '0 0 * * 0'
+  workflow_dispatch:
+    inputs:
+      tags:
+        description: 'Tags to add to docker image (comma separated)'
+        required: false
+        default: 'latest'
 
 jobs:
   docker:
@@ -17,5 +22,5 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           repository: netmeld/netmeld-dev
-          tags: latest
+          tags: ${{ github.event.inputs.tags }}
       


### PR DESCRIPTION
This PR adds the option to manually trigger the `DockerBuild` workflow from the `Actions` tab. The weekly cron build was left as that is a good way to catch when upstream debian:testing dependencies change and break netmeld builds.

Along with manually triggering the build, you can now specify which tags to add to the published images (comma-separated list).
You do not have to specify a tag as the default value is set to `latest`.
**Note:** Specifying tags other than `latest` will result in that image not being used by the CI/CD workflows since they are looking to use `latest`. It would make the most to change tags if you were making a custom image for someone other than the CI/CD workflows to use or make an image "snapshot" at a specific time for testing that you don't want to be clobbered by the next `latest` build.

The PR also adds a check that prevents forks from running this workflow since they won't have the correct secret keys needed to publish the docker images. This isn't a major issue anymore since GitHub changed the way forked repos treat workflows (you have to manually enable workflows after forking now), but it is nice to have.