### PR TITLE
Update `nmdb-import-ping` capabilities

### DIFF
--- a/datastore/common/objects/IpNetwork.cpp
+++ b/datastore/common/objects/IpNetwork.cpp
@@ -46,7 +46,7 @@ namespace netmeld::datastore::objects {
   {
     IpNetwork temp = nmdp::fromString<nmdp::ParserIpAddress, IpAddress>(_addr);
     address        = temp.address;
-    prefix           = temp.prefix;
+    prefix         = temp.prefix;
   }
 
   IpNetwork::IpNetwork(const std::vector<uint8_t>& _addr)

--- a/datastore/importers/nmdb-import-ping/CMakeLists.txt
+++ b/datastore/importers/nmdb-import-ping/CMakeLists.txt
@@ -25,6 +25,7 @@
 # =============================================================================
 
 add_executable(${TGT_TOOL}
+    Parser.cpp
     ${TGT_TOOL}.cpp
   )
 
@@ -33,3 +34,17 @@ target_link_libraries(${TGT_TOOL}
   )
 
 nm_install_bin(${TGT_TOOL})
+
+foreach(ITEM
+    Parser
+  )
+  nm_add_test(${ITEM})
+  target_sources(${TGT_TEST}
+    PRIVATE
+      ${ITEM}.hpp
+      ${ITEM}.cpp
+    )
+  target_link_libraries(${TGT_TEST}
+      netmeld-datastore
+    )
+endforeach()

--- a/datastore/importers/nmdb-import-ping/Parser.cpp
+++ b/datastore/importers/nmdb-import-ping/Parser.cpp
@@ -1,0 +1,148 @@
+// =============================================================================
+// Copyright 2017 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// =============================================================================
+// Maintained by Sandia National Laboratories <Netmeld@sandia.gov>
+// =============================================================================
+
+#include "Parser.hpp"
+
+// =============================================================================
+// Parser logic
+// =============================================================================
+Parser::Parser() : Parser::base_type(start)
+{
+  start =
+    *(pingLinux | pingWindows | ignoredLine)
+      [qi::_val = pnx::bind(&Parser::getData, this)]
+    ;
+
+
+  // Linux
+  pingLinux =
+    linuxHeader > *linuxResponse > ignoredLine > linuxFooter
+      [pnx::bind(&Parser::finalize, this)]
+    ;
+
+  linuxHeader =
+    qi::lit("PING")
+    >> (ipValue | hostname)
+    >> qi::lit('(') >> -(hostname >> qi::lit('(')) >> ipValue >> +qi::lit(')')
+    > +token > qi::eol
+    ;
+
+  linuxResponse =
+    qi::uint_ >> qi::lit("bytes from")
+    >> (  (ipValue)
+        | (token >> qi::lit('(') >> ipValue >> qi::lit(')'))
+       )
+    >> qi::lit(": icmp") >> token >> qi::lit("ttl=") > +token > qi::eol
+      [pnx::bind(&Parser::responsive, this) = true]
+    ;
+
+  linuxFooter =
+    qi::lit("---") > //+token > qi::eol >
+    +(+token > -qi::eol)
+    ;
+
+
+  // Windows
+  pingWindows =
+    windowsHeader > +windowsResponse > ignoredLine > windowsFooter
+      [pnx::bind(&Parser::finalize, this)]
+    ;
+
+  windowsHeader =
+    qi::lit("Pinging") > +token > qi::eol
+    ;
+
+  windowsResponse =
+    qi::lit("Reply from")
+    >> ipAddr
+    >> (qi::lit(": bytes") | qi::lit(": time")) > +token > qi::eol
+      [pnx::bind(&Parser::responsive, this) = true]
+    ;
+
+  windowsFooter =
+    qi::lit("Ping statistics for") > //+token > qi::eol >
+    +(+token > -qi::eol)
+    ;
+
+
+  // General
+  ipValue =
+    ipAddr
+      [pnx::bind(&Parser::tgtIp, this) = qi::_1]
+    >> -(qi::lit('%') >> ifaceName)
+    ;
+
+  hostname =
+    domainName
+      [pnx::bind([&](const std::string& val)
+                   {tgtAliases.push_back(val);},
+                 qi::_1)]
+    ;
+
+  ifaceName =
+    +(  qi::ascii::alnum
+      | qi::ascii::char_("-_.@")
+     )
+    ;
+
+  token =
+    +qi::ascii::graph
+    ;
+
+  ignoredLine =
+    (+token > -qi::eol) | +qi::eol
+    ;
+
+  BOOST_SPIRIT_DEBUG_NODES(
+      (start)
+      (pingLinux)(linuxHeader)(linuxResponse)(linuxFooter)
+      (pingWindows)(windowsHeader)(windowsResponse)(windowsFooter)
+      (ignoredLine)
+      (ipValue)(hostname)(ifaceName)
+      //(token)
+      );
+}
+
+// =============================================================================
+// Parser helper methods
+// =============================================================================
+void
+Parser::finalize()
+{
+  for (const auto& alias : tgtAliases) {
+    tgtIp.addAlias(alias, REASON);
+  }
+  tgtIp.setResponding(responsive);
+  data.push_back(tgtIp);
+}
+
+// Object return
+Result
+Parser::getData()
+{
+  Result r {data};
+  return r;
+}

--- a/datastore/importers/nmdb-import-ping/Parser.hpp
+++ b/datastore/importers/nmdb-import-ping/Parser.hpp
@@ -24,79 +24,91 @@
 // Maintained by Sandia National Laboratories <Netmeld@sandia.gov>
 // =============================================================================
 
-#include <netmeld/datastore/tools/AbstractImportTool.hpp>
+#ifndef PARSER_HPP
+#define PARSER_HPP
 
-#include "Parser.hpp"
+#include <netmeld/datastore/objects/IpAddress.hpp>
+#include <netmeld/datastore/parsers/ParserDomainName.hpp>
+#include <netmeld/datastore/parsers/ParserIpAddress.hpp>
+#include <netmeld/datastore/tools/AbstractImportTool.hpp>
 
 namespace nmdo = netmeld::datastore::objects;
 namespace nmdp = netmeld::datastore::parsers;
 namespace nmdt = netmeld::datastore::tools;
 
+
 // =============================================================================
-// Import tool definition
+// Data containers
 // =============================================================================
-template<typename P, typename R>
-class Tool : public nmdt::AbstractImportTool<P, R>
+typedef std::vector<nmdo::IpAddress>  Result;
+
+
+// =============================================================================
+// Parser definition
+// =============================================================================
+class Parser :
+  public qi::grammar<nmdp::IstreamIter, Result(), qi::ascii::blank_type>
 {
   // ===========================================================================
   // Variables
   // ===========================================================================
-  private: // Variables should generally be private
-  protected: // Variables intended for internal/subclass API
-  public: // Variables should rarely appear at this scope
+  private:
+    Result data;
+
+    const std::string REASON  {"ping"};
+
+    nmdo::IpAddress tgtIp;
+    std::vector<std::string> tgtAliases;
+    bool responsive {false};
+
+  protected:
+    // Rules
+    qi::rule<nmdp::IstreamIter, Result(), qi::ascii::blank_type>
+      start;
+
+    qi::rule<nmdp::IstreamIter, nmdo::IpAddress(), qi::ascii::blank_type>
+      pingResponseLinux,
+      pingResponseWindows,
+      pingResponse;
+
+    qi::rule<nmdp::IstreamIter, qi::ascii::blank_type>
+      pingLinux, linuxHeader, linuxResponse, linuxFooter,
+      pingWindows, windowsHeader, windowsResponse, windowsFooter,
+      ignoredLine;
+
+    qi::rule<nmdp::IstreamIter>
+      ipValue,
+      hostname,
+      ifaceName,
+      token;
+
+    nmdp::ParserDomainName
+      domainName;
+
+    nmdp::ParserIpAddress
+      ipAddr;
+
+  public:
 
 
   // ===========================================================================
   // Constructors
   // ===========================================================================
-  private: // Constructors should rarely appear at this scope
-  protected: // Constructors intended for internal/subclass API
-  public: // Constructors should generally be public
-    Tool() : nmdt::AbstractImportTool<P, R>
-      ("ping -n",       // command line tool imports data from
-       PROGRAM_NAME,    // program name (set in CMakeLists.txt)
-       PROGRAM_VERSION  // program version (set in CMakeLists.txt)
-      )
-    {}
+  private:
+  protected:
+  public: // Constructor is only default and must be public
+    Parser();
 
 
   // ===========================================================================
   // Methods
   // ===========================================================================
-  private: // Methods part of internal API
-    // Overriden from AbstractImportTool
-    void
-    addToolOptions() override
-    {
-      this->opts.removeRequiredOption("device-id");
-      this->opts.addOptionalOption("device-id", std::make_tuple(
-          "device-id",
-          po::value<std::string>(),
-          "Name of device.")
-        );
-    }
+  private:
+    void finalize();
 
-    // Overriden from AbstractImportTool
-    void
-    specificInserts(pqxx::transaction_base& t) override
-    {
-      const auto& toolRunId {this->getToolRunId()};
-      const auto& deviceId  {this->getDeviceId()};
-
-      for (auto& result : this->tResults) {
-        result.save(t, toolRunId, deviceId);
-        LOG_DEBUG << result.toDebugString() << std::endl;
-      }
-    }
-
-  protected: // Methods part of subclass API
-  public: // Methods part of public API
+  protected:
+  public:
+    // Object return
+    Result getData();
 };
-
-
-int
-main(int argc, char** argv)
-{
-  Tool<Parser, Result> tool;
-  return tool.start(argc, argv);
-}
+#endif // PARSER_HPP

--- a/datastore/importers/nmdb-import-ping/Parser.hpp
+++ b/datastore/importers/nmdb-import-ping/Parser.hpp
@@ -67,10 +67,8 @@ class Parser :
       start;
 
     qi::rule<nmdp::IstreamIter, qi::ascii::blank_type>
-      pingLinux,
-        linuxHeader, linuxResponse, linuxNoResponse, linuxFooter,
-      pingWindows,
-        windowsHeader, windowsResponse, windowsNoResponse, windowsFooter,
+      pingLinux, linuxHeader, linuxResponse, linuxFooter,
+      pingWindows, windowsHeader, windowsResponse, windowsFooter,
       ignoredLine;
 
     qi::rule<nmdp::IstreamIter>

--- a/datastore/importers/nmdb-import-ping/Parser.hpp
+++ b/datastore/importers/nmdb-import-ping/Parser.hpp
@@ -66,14 +66,11 @@ class Parser :
     qi::rule<nmdp::IstreamIter, Result(), qi::ascii::blank_type>
       start;
 
-    qi::rule<nmdp::IstreamIter, nmdo::IpAddress(), qi::ascii::blank_type>
-      pingResponseLinux,
-      pingResponseWindows,
-      pingResponse;
-
     qi::rule<nmdp::IstreamIter, qi::ascii::blank_type>
-      pingLinux, linuxHeader, linuxResponse, linuxFooter,
-      pingWindows, windowsHeader, windowsResponse, windowsFooter,
+      pingLinux,
+        linuxHeader, linuxResponse, linuxNoResponse, linuxFooter,
+      pingWindows,
+        windowsHeader, windowsResponse, windowsNoResponse, windowsFooter,
       ignoredLine;
 
     qi::rule<nmdp::IstreamIter>

--- a/datastore/importers/nmdb-import-ping/Parser.test.cpp
+++ b/datastore/importers/nmdb-import-ping/Parser.test.cpp
@@ -1,0 +1,282 @@
+// =============================================================================
+// Copyright 2017 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// =============================================================================
+// Maintained by Sandia National Laboratories <Netmeld@sandia.gov>
+// =============================================================================
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MAIN
+#include <boost/test/unit_test.hpp>
+
+#include <netmeld/datastore/parsers/ParserTestHelper.hpp>
+
+#include "Parser.hpp"
+
+namespace nmdp = netmeld::datastore::parsers;
+
+using qi::ascii::blank;
+
+class TestParser : public Parser {
+    public:
+      using Parser::linuxHeader;
+      using Parser::linuxResponse;
+      using Parser::linuxFooter;
+      using Parser::windowsHeader;
+      using Parser::windowsResponse;
+      using Parser::windowsFooter;
+
+      using Parser::pingLinux;
+      using Parser::pingWindows;
+};
+
+BOOST_AUTO_TEST_CASE(testParts)
+{
+  TestParser tp;
+
+  { // linuxHeader
+    const auto& parserRule {tp.linuxHeader};
+    std::vector<std::string> testsOk {
+      // 6 then 4: -n, no -n, -I
+      "PING host1(1::1) 56 data bytes\n",
+      "PING host1(host2 (1::1)) 56 data bytes\n",
+      "PING 1::1(1::1) from 1::1 eth0: 56 data bytes\n",
+      "PING host1 (1.2.3.4) 56(84) bytes of data.\n",
+      "PING host1 (1.2.3.4) 56(84) bytes of data.\n",
+      "PING 1.2.3.4 (1.2.3.4) from 1.2.3.4 eth0: 56(84) bytes of data.\n",
+    };
+    for (const auto& test : testsOk) {
+      BOOST_TEST(nmdp::test(test.c_str(), parserRule, blank),
+                 "Parse rule 'linuxHeader': " << test);
+    }
+  }
+
+  { // linuxResponse
+    const auto& parserRule {tp.linuxResponse};
+    std::vector<std::string> testsOk {
+      // 6 then 4: -n, no -n, -I
+      "64 bytes from 1::1: icmp_seq=1 ttl=64 time=0.044 ms\n",
+      "64 bytes from host1 (1::1): icmp_seq=1 ttl=64 time=0.047 ms\n",
+      "64 bytes from 1::1%eth0: icmp_seq=1 ttl=64 time=0.051 ms\n",
+      "64 bytes from host1 (1::1%eth0): icmp_seq=1 ttl=64 time=0.047 ms\n",
+      "64 bytes from host1%eth0 (1::1%eth0): icmp_seq=1 ttl=64 time=0.047 ms\n",
+      "64 bytes from 1.2.3.4: icmp_seq=1 ttl=64 time=0.031 ms\n",
+      "64 bytes from host1 (1.2.3.4): icmp_seq=1 ttl=64 time=0.025 ms\n",
+    };
+    for (const auto& test : testsOk) {
+      BOOST_TEST(nmdp::test(test.c_str(), parserRule, blank),
+                 "Parse rule 'linuxResponse':" << test);
+    }
+
+    std::vector<std::string> testsBad {
+      // 6 then 4:
+      "64 bytes from 1::1: icmp_seq=1 Destination unreachable: Beyond scope of source addresss\n",
+      "64 bytes from host1 (1::1): icmp_seq=1 Time to live exceeded\n",
+      "64 bytes from 1::1%eth0: icmp_seq=1 Destination unreachable: Beyond scope of source addresss\n",
+      "64 bytes from host1 (1::1%eth0): icmp_seq=1 Time to live exceeded\n",
+      "64 bytes from host1%eth0 (1::1%eth0): icmp_seq=1 Time to live exceeded\n",
+      "64 bytes from 1.2.3.4: icmp_seq=1 Destination Host Unreachable\n",
+      "64 bytes from host1 (1.2.3.4): icmp_seq=1 Time to live exceeded\n",
+    };
+    for (const auto& test : testsBad) {
+      BOOST_TEST(!nmdp::test(test.c_str(), parserRule, blank),
+                 "Parse rule 'linuxResponse':" << test);
+    }
+  }
+
+  { // linuxFooter
+    const auto& parserRule {tp.linuxFooter};
+    std::vector<std::string> testsOk {
+      R"STR(--- host1 ping statistics ---
+      3 packets transmitted, 3 received, 0% packet loss, time 2031ms
+      rtt min/avg/max/mdev = 0.031/0.060/0.076/0.021 ms)STR",
+      R"STR(--- 1.2.3.4 ping statistics ---
+      3 packets transmitted, 3 received, 0% packet loss, time 2053ms
+      rtt min/avg/max/mdev = 0.024/0.040/0.064/0.017 ms)STR",
+      R"STR(--- 1::1 ping statistics ---
+      3 packets transmitted, 3 received, 0% packet loss, time 2045ms
+      rtt min/avg/max/mdev = 0.047/0.090/0.140/0.038 ms)STR",
+      R"STR(--- 1::1 ping statistics ---
+      3 packets transmitted, 0 received, 100% packet loss, time 2037ms)STR",
+    };
+    for (const auto& test : testsOk) {
+      BOOST_TEST(nmdp::test(test.c_str(), parserRule, blank),
+                 "Parse rule 'linuxFooter':" << test);
+    }
+  }
+
+  { // windowsHeader
+    const auto& parserRule {tp.windowsHeader};
+    std::vector<std::string> testsOk {
+      // 6 then 4:
+      "Pinging 1::1 with 32 bytes of data:\n",
+      "Pinging host1 [1::1] with 32 bytes of data:\n",
+      "Pinging 1.2.3.4 with 32 bytes of data:\n",
+      "Pinging host1 [1.2.3.4] with 32 bytes of data:\n",
+    };
+    for (const auto& test : testsOk) {
+      BOOST_TEST(nmdp::test(test.c_str(), parserRule, blank),
+                 "Parse rule 'windowsHeader': " << test);
+    }
+  }
+
+  { // windowsResponse
+    const auto& parserRule {tp.windowsResponse};
+    std::vector<std::string> testsOk {
+      // 6 then 4:
+      "Reply from ::1: time<1ms\n",
+      "Reply from 1.2.3.4: bytes=32 time<1ms TTL=64\n",
+    };
+    for (const auto& test : testsOk) {
+      BOOST_TEST(nmdp::test(test.c_str(), parserRule, blank),
+                 "Parse rule 'windowsResponse':" << test);
+    }
+
+    std::vector<std::string> testsBad {
+      // 6 then 4:
+      "Reply from ::1: Destination host unreachable.\n",
+      "Reply from 1.2.3.4: Destination host unreachable.\n",
+    };
+    for (const auto& test : testsBad) {
+      BOOST_TEST(!nmdp::test(test.c_str(), parserRule, blank),
+                 "Parse rule 'windowsResponse':" << test);
+    }
+  }
+
+  { // windowsFooter
+    const auto& parserRule {tp.windowsFooter};
+    std::vector<std::string> testsOk {
+      R"STR(Ping statistics for 1.2.3.4:
+          Packets: Sent = 3, Received = 3, Lost = 0 (0% loss),
+          Approximate round trip times in milli-seconds:
+              Minimum = 0ms, Maximum = 0ms, Average = 0ms)STR",
+      R"STR(Ping statistics for 1::1:
+          Packets: Sent = 3, Received = 3, Lost = 0 (0% loss),
+          Approximate round trip times in milli-seconds:
+              Minimum = 0ms, Maximum = 0ms, Average = 0ms)STR",
+    };
+    for (const auto& test : testsOk) {
+      BOOST_TEST(nmdp::test(test.c_str(), parserRule, blank),
+                 "Parse rule 'windowsFooter':" << test);
+    }
+  }
+}
+
+BOOST_AUTO_TEST_CASE(testWhole)
+{
+  TestParser tp;
+
+  const auto& parserRule {tp};
+  std::vector<std::string> testsOk {
+    // Linux
+    R"STR($ ping -nc3 host1
+    PING host1(1::1) 56 data bytes
+    64 bytes from 1::1: icmp_seq=1 ttl=64 time=0.044 ms
+    64 bytes from 1::1: icmp_seq=2 ttl=64 time=0.159 ms
+    64 bytes from 1::1: icmp_seq=3 ttl=64 time=0.156 ms
+
+    --- host1 ping statistics ---
+    3 packets transmitted, 3 received, 0% packet loss, time 2045ms
+    rtt min/avg/max/mdev = 0.044/0.119/0.159/0.053 ms
+    )STR",
+    R"STR($ ping -c3 host1
+    PING host1(host1 (1::1)) 56 data bytes
+    64 bytes from host1 (1::1): icmp_seq=1 ttl=64 time=0.047 ms
+    64 bytes from host1 (1::1): icmp_seq=2 ttl=64 time=0.173 ms
+    64 bytes from host1 (1::1): icmp_seq=3 ttl=64 time=0.162 ms
+
+    --- host1 ping statistics ---
+    3 packets transmitted, 3 received, 0% packet loss, time 2043ms
+    rtt min/avg/max/mdev = 0.047/0.127/0.173/0.056 ms
+    )STR",
+    R"STR($ ping -c3 1.2.3.4
+    PING 1.2.3.4 (1.2.3.4) 56(84) bytes of data.
+    64 bytes from 1.2.3.4: icmp_seq=1 ttl=64 time=0.044 ms
+    64 bytes from 1.2.3.4: icmp_seq=2 ttl=64 time=0.017 ms
+    64 bytes from 1.2.3.4: icmp_seq=3 ttl=64 time=0.032 ms
+
+    --- 1.2.3.4 ping statistics ---
+    3 packets transmitted, 3 received, 0% packet loss, time 2030ms
+    rtt min/avg/max/mdev = 0.017/0.031/0.044/0.011 ms
+    )STR",
+    R"STR($ ping -nc3 test.domain -I eth0
+    PING test.domain (1.2.3.4) from 4.3.2.1 eth0: 56(84) bytes of data.
+
+    --- test.domain ping statistics ---
+    3 packets transmitted, 0 received, 100% packet loss, time 2027ms
+    )STR",
+    R"STR(ping test.domain
+    PING test.domain (1.2.3.4) 56(84) bytes of data.
+    64 bytes from test.domain (1.2.3.4): icmp_seq=1 ttl=64 time=0.026 ms
+    64 bytes from test.domain (1.2.3.4): icmp_seq=2 ttl=64 time=0.032 ms
+    64 bytes from test.domain (1.2.3.4): icmp_seq=3 ttl=64 time=0.030 ms
+    64 bytes from test.domain (1.2.3.4): icmp_seq=4 ttl=64 time=0.030 ms
+    ^C
+    --- test.domain ping statistics ---
+    4 packets transmitted, 4 received, 0% packet loss, time 3063ms
+    rtt min/avg/max/mdev = 0.026/0.029/0.032/0.002 ms)STR",
+
+    // Windows
+    R"STR(ping -n 3 test.domain
+
+    Pinging test.domain [1.2.3.4] with 32 bytes of data:
+    Reply from 1.2.3.4: bytes=32 time=19ms TTL=115
+    Reply from 1.2.3.4: bytes=32 time=25ms TTL=115
+    Reply from 1.2.3.4: bytes=32 time=18ms TTL=115
+
+    Ping statistics for 1.2.3.4:
+        Packets: Sent = 3, Received = 3, Lost = 0 (0% loss),
+        Approximate round trip times in milli-seconds:
+            Minimum = 18ms, Maximum = 25ms, Average = 20ms
+    )STR",
+
+    // Multi
+    R"STR(
+    $ ping -nc3 host1
+    PING host1(1::1) 56 data bytes
+    64 bytes from 1::1: icmp_seq=1 ttl=64 time=0.044 ms
+    64 bytes from 1::1: icmp_seq=2 ttl=64 time=0.159 ms
+    64 bytes from 1::1: icmp_seq=3 ttl=64 time=0.156 ms
+
+    --- host1 ping statistics ---
+    3 packets transmitted, 3 received, 0% packet loss, time 2045ms
+    rtt min/avg/max/mdev = 0.044/0.119/0.159/0.053 ms
+
+    > ping -n 3 test.domain
+
+    Pinging test.domain [1.2.3.4] with 32 bytes of data:
+    Reply from 1.2.3.4: bytes=32 time=19ms TTL=115
+    Reply from 1.2.3.4: bytes=32 time=25ms TTL=115
+    Reply from 1.2.3.4: bytes=32 time=18ms TTL=115
+
+    Ping statistics for 1.2.3.4:
+        Packets: Sent = 3, Received = 3, Lost = 0 (0% loss),
+        Approximate round trip times in milli-seconds:
+            Minimum = 18ms, Maximum = 25ms, Average = 20ms
+    )STR",
+
+  };
+  for (const auto& test : testsOk) {
+    BOOST_TEST(nmdp::test(test.c_str(), parserRule, blank),
+               "Parse rule 'start': " << test);
+  }
+}


### PR DESCRIPTION
Resolves #54.
---
More specifically:
- Splits parser from tool and adds some test cases
- Adds processing support for `ping` commands which don't pass the `-n` option
- Adds processing support for `-I` options as it changes format
- Better handling IPv4 or IPv6 variations for output
- Adds processing of multiple `ping` commands in one input file
- Adds support for for processing Windows `ping`