### PR TITLE
Show cdp multi line

### DIFF
--- a/datastore/importers/nmdb-import-show-cdp-neighbor/Parser.cpp
+++ b/datastore/importers/nmdb-import-show-cdp-neighbor/Parser.cpp
@@ -69,28 +69,27 @@ Parser::Parser() : Parser::base_type(start)
     ;
 
   ipAddressValue =
-    qi::lit("IP") > -(qi::lit("v") > qi::char_("46")) > +qi::blank
-    > -(qi::char_("aA") > qi::lit("ddress: "))
+    qi::lit("IP") > -(qi::lit("v") > qi::char_("46"))
+    > -(qi::char_("aA") > qi::lit("ddress:"))
     > ipAddr
       [pnx::bind([&](nmdo::IpAddress val){nd.ipAddrs.push_back(val);}, qi::_1)]
     // cppcheck-suppress compareBoolExpressionWithInt
-    > *(+qi::blank > token)
+    > *token
     > qi::eol
     ;
 
   platformValue =
-    qi::lit("Platform: ")
+    qi::lit("Platform:")
     > token [pnx::bind(&NeighborData::curVendor, &nd) = qi::_1]
-    > +qi::blank
     > token [pnx::bind(&NeighborData::curModel, &nd) = qi::_1]
     // cppcheck-suppress compareBoolExpressionWithInt
-    > *(+qi::blank > token)
+    > *token
     > qi::eol
     ;
 
   interfaceValue =
-    qi::lit("Interface: ") > token
-    > +qi::blank > qi::lit("Port ID (outgoing port): ")
+    qi::lit("Interface:") > token
+    > qi::lit("Port ID (outgoing port):")
     > token [pnx::bind(&NeighborData::curIfaceName, &nd) = qi::_1]
     > qi::eol
     ;

--- a/datastore/importers/nmdb-import-show-cdp-neighbor/Parser.cpp
+++ b/datastore/importers/nmdb-import-show-cdp-neighbor/Parser.cpp
@@ -46,7 +46,7 @@ Parser::Parser() : Parser::base_type(start)
     ;
 
   header =
-    +qi::ascii::char_("-") > qi::eol
+    +qi::char_('-') > qi::eol
     ;
 
   deviceData =
@@ -55,41 +55,42 @@ Parser::Parser() : Parser::base_type(start)
      | platformValue
      | interfaceValue
      | ((!header) >> ignoredLine)
+     | qi::eol
     )
     ;
 
   hostnameValue =
-    (  (qi::lit("Device") > (qi::space | qi::lit('-')) > qi::lit("ID:"))
+    (  (qi::lit("Device") > (+qi::blank | qi::lit('-')) > qi::lit("ID:"))
      | (qi::lit("SysName:"))
-    ) > -qi::space
+    ) > -(+qi::blank)
     > token [pnx::bind(&NeighborData::curHostname, &nd)
              = pnx::bind(&nmcu::toLower, qi::_1)]
     > qi::eol
     ;
 
   ipAddressValue =
-    qi::lit("IP") > -(qi::lit("v") > qi::char_("46")) > qi::space
-    > -qi::lit("address: ")
+    qi::lit("IP") > -(qi::lit("v") > qi::char_("46")) > +qi::blank
+    > -(qi::char_("aA") > qi::lit("ddress: "))
     > ipAddr
       [pnx::bind([&](nmdo::IpAddress val){nd.ipAddrs.push_back(val);}, qi::_1)]
     // cppcheck-suppress compareBoolExpressionWithInt
-    > *(qi::blank > token)
+    > *(+qi::blank > token)
     > qi::eol
     ;
 
   platformValue =
     qi::lit("Platform: ")
     > token [pnx::bind(&NeighborData::curVendor, &nd) = qi::_1]
-    > qi::space
+    > +qi::blank
     > token [pnx::bind(&NeighborData::curModel, &nd) = qi::_1]
     // cppcheck-suppress compareBoolExpressionWithInt
-    > *(qi::blank > token)
+    > *(+qi::blank > token)
     > qi::eol
     ;
 
   interfaceValue =
     qi::lit("Interface: ") > token
-    > qi::lit(" Port ID (outgoing port): ")
+    > +qi::blank > qi::lit("Port ID (outgoing port): ")
     > token [pnx::bind(&NeighborData::curIfaceName, &nd) = qi::_1]
     > qi::eol
     ;
@@ -110,7 +111,8 @@ Parser::Parser() : Parser::base_type(start)
       (ipAddressValue)
       (platformValue)
       (interfaceValue)
-      //(ignoredLine) (token)
+      (ignoredLine)
+      //(token)
       );
 }
 

--- a/datastore/importers/nmdb-import-show-cdp-neighbor/Parser.cpp
+++ b/datastore/importers/nmdb-import-show-cdp-neighbor/Parser.cpp
@@ -73,7 +73,6 @@ Parser::Parser() : Parser::base_type(start)
     > -(qi::char_("aA") > qi::lit("ddress:"))
     > ipAddr
       [pnx::bind([&](nmdo::IpAddress val){nd.ipAddrs.push_back(val);}, qi::_1)]
-    // cppcheck-suppress compareBoolExpressionWithInt
     > *token
     > qi::eol
     ;
@@ -82,7 +81,6 @@ Parser::Parser() : Parser::base_type(start)
     qi::lit("Platform:")
     > token [pnx::bind(&NeighborData::curVendor, &nd) = qi::_1]
     > token [pnx::bind(&NeighborData::curModel, &nd) = qi::_1]
-    // cppcheck-suppress compareBoolExpressionWithInt
     > *token
     > qi::eol
     ;
@@ -110,7 +108,7 @@ Parser::Parser() : Parser::base_type(start)
       (ipAddressValue)
       (platformValue)
       (interfaceValue)
-      (ignoredLine)
+      //(ignoredLine)
       //(token)
       );
 }

--- a/datastore/importers/nmdb-import-show-cdp-neighbor/Parser.hpp
+++ b/datastore/importers/nmdb-import-show-cdp-neighbor/Parser.hpp
@@ -79,13 +79,13 @@ class Parser :
       config,
       header,
       deviceData,
+      ipAddressValue,
+      platformValue,
+      interfaceValue,
       ignoredLine;
 
     qi::rule<nmdp::IstreamIter>
-      hostnameValue,
-      ipAddressValue,
-      platformValue,
-      interfaceValue;
+      hostnameValue;
 
     qi::rule<nmdp::IstreamIter, std::string()>
       token;

--- a/datastore/importers/nmdb-import-show-cdp-neighbor/Parser.test.cpp
+++ b/datastore/importers/nmdb-import-show-cdp-neighbor/Parser.test.cpp
@@ -73,7 +73,9 @@ BOOST_AUTO_TEST_CASE(testParts)
       "IPv6 1234::1234\n",
       "IP address: 1.2.3.4\n",
       "IPv4 address: 1.2.3.4\n",
+      "IPv4 Address: 1.2.3.4\n",
       "IPv6 address: 1234::1234\n",
+      "IPv6 Address: 1234::1234\n",
       "IP 1.2.3.4 (link-local)\n",
       "IPv4 1.2.3.4 (link-local)\n",
       "IPv6 1234::1234 (link-local)\n",
@@ -176,6 +178,8 @@ Native VLAN: 1234
 SysObjectID: 0.0
 Addresses:
           IPv6 1234::1234
+
+
 ---------------------------------------------
 Device-ID: a1234b4321
 Advertisement version: 2
@@ -199,7 +203,7 @@ Addresses:
                 "Parse rule 'testWhole': " << test);
 //      BOOST_TEST(3 == out.size());
       const auto& data {out[0]};
-      BOOST_TEST(4 == data.ipAddrs.size());
+      BOOST_TEST_REQUIRE(4 == data.ipAddrs.size());
 
       auto ipAddr {data.ipAddrs[0]};
       auto aliases {ipAddr.getAliases()};


### PR DESCRIPTION
Edits to accommodate more formats from samples received.
---
Particularly:
- made many `qi::blank` to be multiple, `+`
- swapped `qi::space` for `qi::blank` as space includes newlines
- added alternate of `Address` as `address`
- changed one test to be a require so it doesn't attempt to continue execution, which causes OOB exception when nothing parses