### PR TITLE
Ipconfig bare i63

### DIFF
--- a/datastore/importers/nmdb-import-ipconfig/Parser.cpp
+++ b/datastore/importers/nmdb-import-ipconfig/Parser.cpp
@@ -50,7 +50,6 @@ Parser::Parser() : Parser::base_type(start)
     *(ignoredLine) // Skip garbage after
     ;
 
-
   compartmentHeader =
     +qi::lit('=') > qi::eol > ignoredLine > +qi::lit('=') > qi::eol
     ;

--- a/datastore/importers/nmdb-import-ipconfig/Parser.cpp
+++ b/datastore/importers/nmdb-import-ipconfig/Parser.cpp
@@ -72,8 +72,8 @@ Parser::Parser() : Parser::base_type(start)
           [(pnx::bind(&Parser::setIfaceDown, this))]
      | ("Connection-specific DNS Suffix" >> dots > -token
           [(pnx::bind(&Parser::setIfaceDnsSuffix, this, qi::_1))] > qi::eol)
-     | ("Default Gateway" >> dots > *(getIp
-          [(pnx::bind(&Parser::addRoute, this, qi::_1))] > qi::eol))
+     | ("Default Gateway" >> dots > (+(getIp
+          [(pnx::bind(&Parser::addRoute, this, qi::_1))] > qi::eol) | qi::eol ))
      | servers
      | ignoredLine
     ) >> *qi::eol
@@ -176,7 +176,13 @@ Parser::addIfaceIp(nmdo::IpAddress& _ipAddr)
 {
   auto& iface {d.ifaces[curIfaceName]};
   if (dnsSuffix.count(curIfaceName)) {
-    auto alias {curHostname + '.' + dnsSuffix[curIfaceName]};
+    auto alias {curHostname};
+
+    if (!curHostname.empty()) {
+      alias += '.';
+    }
+    alias += dnsSuffix[curIfaceName];
+
     _ipAddr.addAlias(alias, "ipconfig");
   }
   iface.addIpAddress(_ipAddr);

--- a/datastore/importers/nmdb-import-ipconfig/Parser.hpp
+++ b/datastore/importers/nmdb-import-ipconfig/Parser.hpp
@@ -76,7 +76,7 @@ class Parser :
       getIp;
 
     qi::rule<nmdp::IstreamIter, std::string()>
-      token;
+      token, ifaceType;
 
     qi::rule<nmdp::IstreamIter>
       dots,

--- a/datastore/importers/nmdb-import-ipconfig/Parser.hpp
+++ b/datastore/importers/nmdb-import-ipconfig/Parser.hpp
@@ -65,7 +65,7 @@ class Parser :
       start;
 
     qi::rule<nmdp::IstreamIter, qi::ascii::blank_type>
-      compartmentHeader;
+      hostData, compartmentHeader;
 
     qi::rule<nmdp::IstreamIter, qi::ascii::blank_type>
       adapter, ifaceTypeName,

--- a/datastore/importers/nmdb-import-ipconfig/nmdb-import-ipconfig.cpp
+++ b/datastore/importers/nmdb-import-ipconfig/nmdb-import-ipconfig.cpp
@@ -36,7 +36,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
 {
   public:
     Tool() : nmdt::AbstractImportTool<P,R>
-      ("ipconfig /allcompartments /all", PROGRAM_NAME, PROGRAM_VERSION)
+      ("ipconfig [/allcompartments /all] [/all]", PROGRAM_NAME, PROGRAM_VERSION)
     {}
 
     void


### PR DESCRIPTION
Related to issue #63  
Adds support for parsing the `ipconfig` command without `/all` or `/all /allcompartments`