### PR TITLE
Port list config path i59

### DIFF
--- a/datastore/exporters/nmdb-export-port-list/nmdb-export-port-list.cpp
+++ b/datastore/exporters/nmdb-export-port-list/nmdb-export-port-list.cpp
@@ -119,9 +119,10 @@ class Tool : public nmdt::AbstractExportTool
             "Use ports from database instead of from resource file.")
           );
           
+      auto& nmfm {nmcu::FileManager::getInstance()};
       opts.addOptionalOption("config-path", std::make_tuple(
             "config-path,c",
-            po::value<std::string>(),
+            po::value<std::string>()->default_value(nmfm.getConfPath()/"port-list.conf"),
             "Use specified port configuration file instead of the default.")
           );
 
@@ -167,7 +168,7 @@ class Tool : public nmdt::AbstractExportTool
       }
       else {
         // Open and parse the port list file.
-        sfs::path const portListPath {this->getConfPath()};
+        sfs::path const portListPath {sfs::path(opts.getValue("config-path"))};
 
         Results portRanges {
           nmdp::fromFilePath<Parser, Results>(portListPath.string())
@@ -255,14 +256,6 @@ class Tool : public nmdt::AbstractExportTool
       LOG_NOTICE << nmapPorts << std::endl;
 
       return nmcu::Exit::SUCCESS;
-    }
-
-    sfs::path getConfPath() {        
-      auto& nmfm {nmcu::FileManager::getInstance()};
-      if (opts.exists("config-path")) {
-        return sfs::path(opts.getValue("config-path"));
-      }
-      return nmfm.getConfPath()/"port-list.conf";
     }
 
 };

--- a/datastore/exporters/nmdb-export-port-list/nmdb-export-port-list.cpp
+++ b/datastore/exporters/nmdb-export-port-list/nmdb-export-port-list.cpp
@@ -118,6 +118,13 @@ class Tool : public nmdt::AbstractExportTool
             NULL_SEMANTIC,
             "Use ports from database instead of from resource file.")
           );
+          
+      opts.addOptionalOption("config-path", std::make_tuple(
+            "config-path,c",
+            po::value<std::string>(),
+            "Use specified port configuration file instead of the default.")
+          );
+
     }
 
     int
@@ -160,8 +167,8 @@ class Tool : public nmdt::AbstractExportTool
       }
       else {
         // Open and parse the port list file.
-        auto& nmfm {nmcu::FileManager::getInstance()};
-        sfs::path const portListPath {nmfm.getConfPath()/"port-list.conf"};
+        sfs::path const portListPath {this->getConfPath()};
+
 
         Results portRanges {
           nmdp::fromFilePath<Parser, Results>(portListPath.string())
@@ -250,6 +257,15 @@ class Tool : public nmdt::AbstractExportTool
 
       return nmcu::Exit::SUCCESS;
     }
+
+    sfs::path getConfPath() {        
+      auto& nmfm {nmcu::FileManager::getInstance()};
+      if (opts.exists("config-path")) {
+        return sfs::path(opts.getValue("config-path"));
+      }
+      return nmfm.getConfPath()/"port-list.conf";
+    }
+
 };
 
 

--- a/datastore/exporters/nmdb-export-port-list/nmdb-export-port-list.cpp
+++ b/datastore/exporters/nmdb-export-port-list/nmdb-export-port-list.cpp
@@ -169,7 +169,6 @@ class Tool : public nmdt::AbstractExportTool
         // Open and parse the port list file.
         sfs::path const portListPath {this->getConfPath()};
 
-
         Results portRanges {
           nmdp::fromFilePath<Parser, Results>(portListPath.string())
         };


### PR DESCRIPTION
#59 

Adds option for specifying an alternate port configuration file in the `nmdb-export-port-list` module