### PR TITLE
data-lake inserter, allow committer value

### DIFF
--- a/datalake/common/objects/DataEntry.cpp
+++ b/datalake/common/objects/DataEntry.cpp
@@ -52,6 +52,10 @@ namespace netmeld::datalake::objects {
   { return pipedData; }
 
   std::string
+  DataEntry::getCommitter() const
+  { return committer; }
+
+  std::string
   DataEntry::getDataPath() const
   { return dataPath; }
 
@@ -64,12 +68,12 @@ namespace netmeld::datalake::objects {
   { return ingestTool; }
 
   std::string
-  DataEntry::getToolArgs() const
-  { return toolArgs; }
-
-  std::string
   DataEntry::getNewName() const
   { return newName; }
+
+  std::string
+  DataEntry::getToolArgs() const
+  { return toolArgs; }
 
   std::string
   DataEntry::getSaveName() const
@@ -106,6 +110,22 @@ namespace netmeld::datalake::objects {
     }
 
     return nmcu::trim(oss.str());
+  }
+
+  void
+  DataEntry::setCommitter(const std::string& _committer)
+  {
+    // `git`:
+    //   - have at least one character not of (see git's ident.c:crud())
+    std::regex gitCrudList {"^[\\x00-\\x20\\.,:;<>\"'\\\\]+$"};
+    if (std::regex_match(_committer, gitCrudList)) {
+      LOG_DEBUG << "Ignoring 'committer' value as it only contains"
+                << " invalid characters (maybe non-printable): "
+                << _committer << '\n';
+      return;
+    }
+
+    committer = _committer;
   }
 
   void

--- a/datalake/common/objects/DataEntry.hpp
+++ b/datalake/common/objects/DataEntry.hpp
@@ -47,6 +47,7 @@ namespace netmeld::datalake::objects {
       std::string ingestTool {""};
       std::string toolArgs   {""};
       std::string newName    {""};
+      std::string committer  {""};
 
     public: // Variables should rarely appear at this scope
 
@@ -67,6 +68,7 @@ namespace netmeld::datalake::objects {
     public: // Methods part of public API
       bool isPipedData() const;
 
+      std::string getCommitter() const;
       std::string getDataPath() const;
       std::string getDeviceId() const;
       std::string getIngestCmd() const;
@@ -75,6 +77,7 @@ namespace netmeld::datalake::objects {
       std::string getSaveName() const;
       std::string getToolArgs() const;
 
+      void setCommitter(const std::string&);
       void setDataPath(const std::string&);
       void setDeviceId(const std::string&);
       void setIngestTool(const std::string&);

--- a/datalake/common/objects/DataEntry.test.cpp
+++ b/datalake/common/objects/DataEntry.test.cpp
@@ -44,18 +44,58 @@ BOOST_AUTO_TEST_CASE(testConstructors)
 {
   {
     TestDataEntry tde;
-    BOOST_CHECK(tde.getDeviceId().empty());
+    BOOST_CHECK(tde.getCommitter().empty());
     BOOST_CHECK(tde.getDataPath().empty());
+    BOOST_CHECK(tde.getDeviceId().empty());
+    BOOST_CHECK(tde.getIngestCmd().empty());
     BOOST_CHECK(tde.getIngestTool().empty());
-    BOOST_CHECK(tde.getToolArgs().empty());
     BOOST_CHECK(tde.getNewName().empty());
     BOOST_CHECK(tde.getSaveName().empty());
-    BOOST_CHECK(tde.getIngestCmd().empty());
+    BOOST_CHECK(tde.getToolArgs().empty());
   }
 }
 
 BOOST_AUTO_TEST_CASE(testSetters)
 {
+  {
+    TestDataEntry tde;
+
+    std::vector<std::string> testsOk {
+      "Some One",
+      "Some Other <email>",
+      "Some Other1<email@other.new>",
+    };
+
+    for (const auto& committer : testsOk) {
+      tde.setCommitter(committer);
+      BOOST_CHECK_EQUAL(committer, tde.getCommitter());
+    }
+
+    std::vector<std::string> testsBad {
+      " ", ".", ",", ":", ";", "<", ">", "\"", "'", "\\",
+      " .,:;<>\"'\\",
+    };
+    const std::string empty {""};
+    tde.setCommitter(empty); // reset
+    for (const auto& committer : testsBad) {
+      tde.setCommitter(committer);
+      BOOST_CHECK_EQUAL(empty, tde.getCommitter());
+    }
+    int i {0};
+    for (char c {'\0'}; i <= 20; ++i, ++c) {
+      std::string s(1,c);
+      tde.setCommitter(s);
+      BOOST_CHECK_EQUAL(empty, tde.getCommitter());
+    }
+
+    BOOST_CHECK(tde.getDataPath().empty());
+    BOOST_CHECK(tde.getDeviceId().empty());
+    BOOST_CHECK(tde.getIngestCmd().empty());
+    BOOST_CHECK(tde.getIngestTool().empty());
+    BOOST_CHECK(tde.getNewName().empty());
+    BOOST_CHECK(tde.getSaveName().empty());
+    BOOST_CHECK(tde.getToolArgs().empty());
+  }
   {
     TestDataEntry tde;
     const std::string path {"../maybe_some/non-existant/path"};
@@ -64,11 +104,12 @@ BOOST_AUTO_TEST_CASE(testSetters)
     BOOST_CHECK_EQUAL(std::filesystem::absolute(path), tde.getDataPath());
     BOOST_CHECK_EQUAL("path", tde.getSaveName());
 
+    BOOST_CHECK(tde.getCommitter().empty());
     BOOST_CHECK(tde.getDeviceId().empty());
-    BOOST_CHECK(tde.getIngestTool().empty());
-    BOOST_CHECK(tde.getToolArgs().empty());
-    BOOST_CHECK(tde.getNewName().empty());
     BOOST_CHECK(tde.getIngestCmd().empty());
+    BOOST_CHECK(tde.getIngestTool().empty());
+    BOOST_CHECK(tde.getNewName().empty());
+    BOOST_CHECK(tde.getToolArgs().empty());
   }
 
   {
@@ -78,6 +119,7 @@ BOOST_AUTO_TEST_CASE(testSetters)
 
     BOOST_CHECK_EQUAL(devId, tde.getDeviceId());
 
+    BOOST_CHECK(tde.getCommitter().empty());
     BOOST_CHECK(tde.getDataPath().empty());
     BOOST_CHECK(tde.getIngestTool().empty());
     BOOST_CHECK(tde.getToolArgs().empty());
@@ -103,6 +145,7 @@ BOOST_AUTO_TEST_CASE(testSetters)
     BOOST_CHECK_EQUAL(toolName, tde.getIngestTool());
     BOOST_CHECK_EQUAL((toolName+args), tde.getIngestCmd());
 
+    BOOST_CHECK(tde.getCommitter().empty());
     BOOST_CHECK(tde.getDataPath().empty());
     BOOST_CHECK(tde.getDeviceId().empty());
     BOOST_CHECK(tde.getToolArgs().empty());
@@ -118,6 +161,7 @@ BOOST_AUTO_TEST_CASE(testSetters)
     BOOST_CHECK_EQUAL(name, tde.getNewName());
     BOOST_CHECK_EQUAL(name, tde.getSaveName());
 
+    BOOST_CHECK(tde.getCommitter().empty());
     BOOST_CHECK(tde.getDataPath().empty());
     BOOST_CHECK(tde.getDeviceId().empty());
     BOOST_CHECK(tde.getIngestTool().empty());
@@ -135,6 +179,7 @@ BOOST_AUTO_TEST_CASE(testSetters)
     BOOST_CHECK_EQUAL(name, tde.getNewName());
     BOOST_CHECK_EQUAL(name, tde.getSaveName());
 
+    BOOST_CHECK(tde.getCommitter().empty());
     BOOST_CHECK(tde.getDeviceId().empty());
     BOOST_CHECK(tde.getIngestTool().empty());
     BOOST_CHECK(tde.getToolArgs().empty());
@@ -148,6 +193,7 @@ BOOST_AUTO_TEST_CASE(testSetters)
 
     BOOST_CHECK_EQUAL(args, tde.getToolArgs());
 
+    BOOST_CHECK(tde.getCommitter().empty());
     BOOST_CHECK(tde.getDeviceId().empty());
     BOOST_CHECK(tde.getDataPath().empty());
     BOOST_CHECK(tde.getIngestTool().empty());

--- a/datalake/nmdl-insert/nmdl-insert.cpp
+++ b/datalake/nmdl-insert/nmdl-insert.cpp
@@ -113,6 +113,11 @@ class Tool : public nmdlt::AbstractDatalakeTool
             "Data file name to use instead when data path file is stored;"
             " not a path.  Required when `--pipe` used.")
           );
+      opts.addAdvancedOption("committer", std::make_tuple(
+            "committer",
+            po::value<std::string>(),
+            "Value to use for commit author")
+          );
     }
 
   protected: // Methods part of subclass API
@@ -158,9 +163,14 @@ class Tool : public nmdlt::AbstractDatalakeTool
         de.setToolArgs(toolArgs);
       }
 
-      if (opts.exists("rename")){
+      if (opts.exists("rename")) {
         const auto& newName {opts.getValue("rename")};
         de.setNewName(newName);
+      }
+
+      if (opts.exists("committer")) {
+        const auto& committer {opts.getValue("committer")};
+        de.setCommitter(committer);
       }
 
       dataLake->commit(de);


### PR DESCRIPTION
Added option to allow specifying a "committer" value during inserts to the data-lake.  This does a couple of things:
- It provides a common way for the data-lake back end logic to get an identity (if provided) of a committer.  Since it's optional, it would simply behave as it normally does if not provided (i.e., do nothing or rely on pre-configuring the back-end storage mechanism separately).
- It allows for multiple parties to insert data to the same repo with different identities, without having to configure the back-end separately (e.g., don't have to create a full git-config environment for just inserting data).
- The `git` handler handles some `git` specific nuances regarding the committer value.
  - For example, it allows either `Some Name <some@email>` (i.e., a properly formatted git `--author` value) as well as simply `Some Name` (i.e., not valid `--author` value).
- The `DataEntry` object does some character validation (if invalid it leaves the value as empty) to ensure it will successfully insert the data into the repo.
- I left it as an `Advanced Option` (instead of `Optional`) since it has limited testing done on/to it.
