### PR TITLE
Various bug fixes

### DIFF
--- a/datastore/importers/nmdb-import-ip-addr-show/CMakeLists.txt
+++ b/datastore/importers/nmdb-import-ip-addr-show/CMakeLists.txt
@@ -34,3 +34,17 @@ target_link_libraries(${TGT_TOOL}
   )
 
 nm_install_bin(${TGT_TOOL})
+
+foreach(ITEM
+    Parser
+  )
+  nm_add_test(${ITEM})
+  target_sources(${TGT_TEST}
+    PRIVATE
+      ${ITEM}.hpp
+      ${ITEM}.cpp
+    )
+  target_link_libraries(${TGT_TEST}
+      netmeld-datastore
+    )
+endforeach()

--- a/datastore/importers/nmdb-import-ip-addr-show/Parser.hpp
+++ b/datastore/importers/nmdb-import-ip-addr-show/Parser.hpp
@@ -56,6 +56,10 @@ class Parser:
   // Variables
   // ===========================================================================
   private:
+    // Supporting data structures
+    Data d;
+
+  protected:
     // Rules
     qi::rule<nmdp::IstreamIter, Result(), qi::ascii::blank_type>
       start;
@@ -81,9 +85,6 @@ class Parser:
 
     nmdp::ParserIpAddress
       ipAddr;
-
-    // Supporting data structures
-    Data d;
 
   // ===========================================================================
   // Constructors

--- a/datastore/importers/nmdb-import-ip-addr-show/Parser.test.cpp
+++ b/datastore/importers/nmdb-import-ip-addr-show/Parser.test.cpp
@@ -115,48 +115,48 @@ BOOST_AUTO_TEST_CASE(testRules)
   }
 
   {
-      const auto& parserRule {tp.iface};
-      // OK
-      std::vector<std::string> testsOk {
-        {R"(1: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000
-                link/ether 00:11:22:33:44:55 brd ff:ff:ff:ff:ff:ff
-                altname enp2s1
-                inet 1.1.1.1/24 scope global ens33
-                   valid_lft forever preferred_lft forever
-                inet6 fe80::1:1111:1:1/64 scope link 
-                   valid_lft forever preferred_lft forever
+    const auto& parserRule {tp.iface};
+    // OK
+    std::vector<std::string> testsOk {
+      {R"(1: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000
+              link/ether 00:11:22:33:44:55 brd ff:ff:ff:ff:ff:ff
+              altname enp2s1
+              inet 1.1.1.1/24 scope global ens33
+                 valid_lft forever preferred_lft forever
+              inet6 fe80::1:1111:1:1/64 scope link 
+                 valid_lft forever preferred_lft forever
 )"},
-        {R"(255: t0: flags mtu 1 tokens
-                link/type 00:11:22:33:44:55 brd ff:ff:ff:ff:ff:ff opt tokens
-                altname name1
-                altname name2
-                inet 1.1.1.1/24 scope host
-                inet 2.2.2.2/24 scope host
-                inet 3.3.3.3/24 scope host
+      {R"(255: t0: flags mtu 1 tokens
+              link/type 00:11:22:33:44:55 brd ff:ff:ff:ff:ff:ff opt tokens
+              altname name1
+              altname name2
+              inet 1.1.1.1/24 scope host
+              inet 2.2.2.2/24 scope host
+              inet 3.3.3.3/24 scope host
 )"},
-        {R"(255: t0: flags mtu 1
-                link/type
+      {R"(255: t0: flags mtu 1
+              link/type
 )"},
-        {R"(255: t0: flags mtu 1
-                link/type brd ff:ff:ff:ff:ff:ff
+      {R"(255: t0: flags mtu 1
+              link/type brd ff:ff:ff:ff:ff:ff
 )"},
-        {R"(255: t0: flags mtu 1
-                link/type brd ff:ff:ff:ff:ff:ff opt tokens
+      {R"(255: t0: flags mtu 1
+              link/type brd ff:ff:ff:ff:ff:ff opt tokens
 )"},
-        {R"(255: t0: flags mtu 1
-                link/type
-                altname name1
+      {R"(255: t0: flags mtu 1
+              link/type
+              altname name1
 )"},
-        {R"(255: t0: flags mtu 1
-                link/type
-                inet 1.1.1.1/24 scope host
+      {R"(255: t0: flags mtu 1
+              link/type
+              inet 1.1.1.1/24 scope host
 )"},
-      };
-      for (const auto& test : testsOk) {
-        nmdo::Interface out;
-        BOOST_TEST(nmdp::testAttr(test.c_str(), parserRule, out, blank),
-                   "Parse rule 'inetLine': " << test);
-        BOOST_TEST(out.isValid());
-      }
+    };
+    for (const auto& test : testsOk) {
+      nmdo::Interface out;
+      BOOST_TEST(nmdp::testAttr(test.c_str(), parserRule, out, blank),
+                 "Parse rule 'inetLine': " << test);
+      BOOST_TEST(out.isValid());
+    }
   }
 }

--- a/datastore/importers/nmdb-import-ip-addr-show/Parser.test.cpp
+++ b/datastore/importers/nmdb-import-ip-addr-show/Parser.test.cpp
@@ -37,7 +37,8 @@ namespace nmdp = netmeld::datastore::parsers;
 
 using qi::ascii::blank;
 
-class TestParser : public Parser {
+class TestParser : public Parser
+{
   public:
     using Parser::iface;
     using Parser::inetLine;

--- a/datastore/importers/nmdb-import-ip-addr-show/Parser.test.cpp
+++ b/datastore/importers/nmdb-import-ip-addr-show/Parser.test.cpp
@@ -1,0 +1,161 @@
+// =============================================================================
+// Copyright 2017 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// =============================================================================
+// Maintained by Sandia National Laboratories <Netmeld@sandia.gov>
+// =============================================================================
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MAIN
+#include <boost/test/unit_test.hpp>
+
+#include <netmeld/datastore/parsers/ParserTestHelper.hpp>
+
+#include "Parser.hpp"
+
+namespace nmdo = netmeld::datastore::objects;
+namespace nmdp = netmeld::datastore::parsers;
+
+using qi::ascii::blank;
+
+class TestParser : public Parser {
+  public:
+    using Parser::iface;
+    using Parser::inetLine;
+    using Parser::ifaceName;
+};
+
+BOOST_AUTO_TEST_CASE(testRules)
+{
+  TestParser tp;
+
+  {
+    const auto& parserRule {tp.ifaceName};
+    // OK
+    std::vector<std::tuple<std::string, std::string>> testsOk {
+      // {test, expected}
+      {"lo", "lo"},
+      {"dummy0", "dummy0"},
+      {"special-_.@chars4", "special-_.@chars4"},
+    };
+    for (const auto& [test, expected] : testsOk) {
+      std::string out;
+      BOOST_TEST(nmdp::testAttr(test.c_str(), parserRule, out),
+                 "Parse rule 'ifaceName': " << test);
+      BOOST_TEST(expected == out);
+    }
+    std::vector<std::string> testsBad {
+      // {test}
+      {" lo"}, // rule doesn't handle spaces
+      {"lo "},
+      {"lo:"}, // rule doesn't fully parse, important for iface rule
+    };
+    for (const auto& test : testsBad) {
+      std::string out;
+      BOOST_TEST(!nmdp::testAttr(test.c_str(), parserRule, out),
+                 "Parse rule 'ifaceName': " << test);
+    }
+  }
+
+  {
+    const auto& parserRule {tp.inetLine};
+    // OK
+    { // v4
+      std::vector<std::string> testsOk {
+        // {test}
+        {"inet 1.1.1.1/24 brd 2.2.2.2/24 scope global dummy0\n"
+         "valid_lft forever preferred_lft forever)\n"},
+        {"inet 1.1.1.1/24 scope global dummy0\n"},
+        {"inet 1.1.1.1/24 scope host\n"},
+      };
+      const auto& tip {nmdo::IpAddress("1.1.1.1/24")};
+      for (const auto& test : testsOk) {
+        nmdo::IpAddress out;
+        BOOST_TEST(nmdp::testAttr(test.c_str(), parserRule, out, blank),
+                   "Parse rule 'inetLine': " << test);
+        BOOST_TEST(tip == out);
+      }
+    }
+    { // v6
+      std::vector<std::string> testsOk {
+        // {test}
+        {"inet6 1::1/64 brd 2::2/64 scope global dummy0\n"
+         "valid_lft forever preferred_lft forever)\n"},
+        {"inet6 1::1/64 scope global dummy0\n"},
+        {"inet6 1::1/64 scope host\n"},
+      };
+      const auto& tip {nmdo::IpAddress("1::1/64")};
+      for (const auto& test : testsOk) {
+        nmdo::IpAddress out;
+        BOOST_TEST(nmdp::testAttr(test.c_str(), parserRule, out, blank),
+                   "Parse rule 'inetLine': " << test);
+        BOOST_TEST(tip == out);
+      }
+    }
+  }
+
+  {
+      const auto& parserRule {tp.iface};
+      // OK
+      std::vector<std::string> testsOk {
+        {R"(1: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000
+                link/ether 00:11:22:33:44:55 brd ff:ff:ff:ff:ff:ff
+                altname enp2s1
+                inet 1.1.1.1/24 scope global ens33
+                   valid_lft forever preferred_lft forever
+                inet6 fe80::1:1111:1:1/64 scope link 
+                   valid_lft forever preferred_lft forever
+)"},
+        {R"(255: t0: flags mtu 1 tokens
+                link/type 00:11:22:33:44:55 brd ff:ff:ff:ff:ff:ff opt tokens
+                altname name1
+                altname name2
+                inet 1.1.1.1/24 scope host
+                inet 2.2.2.2/24 scope host
+                inet 3.3.3.3/24 scope host
+)"},
+        {R"(255: t0: flags mtu 1
+                link/type
+)"},
+        {R"(255: t0: flags mtu 1
+                link/type brd ff:ff:ff:ff:ff:ff
+)"},
+        {R"(255: t0: flags mtu 1
+                link/type brd ff:ff:ff:ff:ff:ff opt tokens
+)"},
+        {R"(255: t0: flags mtu 1
+                link/type
+                altname name1
+)"},
+        {R"(255: t0: flags mtu 1
+                link/type
+                inet 1.1.1.1/24 scope host
+)"},
+      };
+      for (const auto& test : testsOk) {
+        nmdo::Interface out;
+        BOOST_TEST(nmdp::testAttr(test.c_str(), parserRule, out, blank),
+                   "Parse rule 'inetLine': " << test);
+        BOOST_TEST(out.isValid());
+      }
+  }
+}

--- a/playbook/nmdb-playbook-export-scans/writers/Context.cpp
+++ b/playbook/nmdb-playbook-export-scans/writers/Context.cpp
@@ -487,19 +487,23 @@ namespace netmeld::playbook::export_scans {
       const auto& portProto, const auto& pps
     ) const
   {
+    std::string cellFrameDest {"[leftframe=on"};
+    if ("" != destIp) {
+      cellFrameDest = "[topframe=on, leftframe=on";
+    }
     oss << R"(
       % row
       \startxrow)" << rowFrame << R"(
         \startxcell[leftframe=on]   % next hop ip (hostname)
           \type{)" << nextHopIp << R"(} \type{)" << nextHopName << R"(}
         \stopxcell
-        \startxcell[leftframe=on]   % destination ip (hostname)
+        \startxcell)" << cellFrameDest << R"(]   % destination ip (hostname)
           \type{)" << destIp << R"(} \type{)" << destName << R"(}
         \stopxcell
-        \startxcell[leftframe=on]   % port/protocol
+        \startxcell)" << cellFrameDest << R"(]   % port/protocol
           \type{)" << portProto << R"(}
         \stopxcell
-        \startxcell[rightframe=on]  % port state/reason
+        \startxcell)" << cellFrameDest << R"(, rightframe=on]  % port state/reason
           {\tt ()" << pps << R"()}
         \stopxcell
       \stopxrow

--- a/playbook/nmdb-playbook/CommandRunnerSingleton.cpp
+++ b/playbook/nmdb-playbook/CommandRunnerSingleton.cpp
@@ -88,7 +88,7 @@ namespace netmeld::playbook {
     if (isEnabled(++commandIdNumber)) {
       LOG_INFO << commandIdNumber << ": " << command << std::endl;
       if (execute) {
-        return nmcu::cmdExecOrExit(command);
+        return (0 == nmcu::cmdExecOrExit(command));
       }
     }
 

--- a/playbook/nmdb-playbook/nmdb-playbook.cpp
+++ b/playbook/nmdb-playbook/nmdb-playbook.cpp
@@ -513,6 +513,7 @@ class Tool : public nmdt::AbstractDatastoreTool
 
       pqxx::read_transaction t {db};
       pqxx::result playbookIpSourceRows {t.exec_prepared(query)};
+      t.commit();
       for (const auto& playbookIpSourceRow : playbookIpSourceRows) {
         size_t playbookStage;
         playbookIpSourceRow.at("playbook_stage").to(playbookStage);
@@ -856,6 +857,7 @@ class Tool : public nmdt::AbstractDatastoreTool
           pqxx::result rows {
               t.exec_prepared("select_network_and_broadcast", pc.srcIpAddr)
             };
+          t.commit();
 
           for (const auto& row : rows) {
             row.at("ip_net").to(pc.ipNet);

--- a/playbook/nmdb-playbook/plays.yaml
+++ b/playbook/nmdb-playbook/plays.yaml
@@ -59,7 +59,7 @@ templates:
     - title: nmap IPv4 router reachablility
       cmd: clw nmap
       opts: &opts-nmap-router-reachability
-      - -n -sn -e {{linkName}} {{rtrIpAddr}}
+      - -d -n -sn -e {{linkName}} {{rtrIpAddr}}
       - 2>&1 | grep 'Host is up'
     ipv6:
     - title: nmap IPv6 router reachability
@@ -218,7 +218,7 @@ intra-network:
         - title: nmap IPv4 ARP host discovery
           cmd: clw nmap
           opts:
-          - -T4 -n -e {{linkName}} -PR
+          - -d -T4 -n -e {{linkName}} -PR
           - -sn
           - --script '(ip-forwarding)'
           - "{{ipNet}}"
@@ -227,7 +227,7 @@ intra-network:
         - title: nmap IPv4 IP protocol scan
           cmd: clw nmap
           opts:
-          - -T4 -n -e {{linkName}} -PR
+          - -d -T4 -n -e {{linkName}} -PR
           - -sO
           - "{{ipNet}}"
           - --excludefile
@@ -236,7 +236,7 @@ intra-network:
         - title: nmap IPv6 ARP host discovery
           cmd: clw nmap -6
           opts:
-          - -T4 -n -e {{linkName}} -PR
+          - -d -T4 -n -e {{linkName}} -PR
           - -sn
           - --script
             '(ip-forwarding) or (targets-ipv6-* or ipv6-node-info)'
@@ -247,7 +247,7 @@ intra-network:
         - title: nmap IPv6 IP protocol scan
           cmd: clw nmap -6
           opts:
-          - -T4 -n -e {{linkName}} -PR
+          - -d -T4 -n -e {{linkName}} -PR
           - -sO
           - --script '(targets-ipv6-* or ipv6-node-info)'
           - --script-args 'newtargets'
@@ -260,7 +260,7 @@ intra-network:
         - title: nmap IPv4 DNS lookup, default resolver
           cmd: clw nmap
           opts: &opts-nmap-ipv4-dns-intra
-          - -T4 -R -e {{linkName}} -sL --resolve-all
+          - -d -T4 -R -e {{linkName}} -sL --resolve-all
           - "{{ipNet}}"
           - --excludefile
           - *path-roe-exclude-ips
@@ -275,7 +275,8 @@ intra-network:
         - title: nmap IPv4 TCP port scan
           cmd: clw nmap
           opts: &opts-nmap-ipv4-tcp-port-scan
-          - -T4 -n -e {{linkName}} -PR
+          - -d -T4 -n -e {{linkName}} -PR
+          - --host-timeout 30m --script-timeout 5m
           - -Pn -O --script
             '(banner or dns-nsid or ntp-info or rpcinfo
               or ssh-hostkey or ssh2-enum-algos or ssl-cert
@@ -289,7 +290,8 @@ intra-network:
         - title: nmap IPv4 UDP port scan
           cmd: clw nmap
           opts: &opts-nmap-ipv4-udp-port-scan
-          - -T4 -n -e {{linkName}} -PR
+          - -d -T4 -n -e {{linkName}} -PR
+          - --host-timeout 30m --script-timeout 2m
           - -Pn -O --script
             '(banner or dns-nsid or ntp-info or rpcinfo
               or ssh-hostkey or ssh2-enum-algos or ssl-cert
@@ -312,7 +314,8 @@ intra-network:
         - title: nmap IPv4 TCP service scan
           cmd: clw nmap
           opts: &opts-nmap-ipv4-tcp-service-scan
-          - -T4 -n -e {{linkName}} -PR
+          - -d -T4 -n -e {{linkName}} -PR
+          - --host-timeout 30m --script-timeout 10m
           - -A --script
             '((default or discovery) and not (external or brute or dos))'
           - -sS -p `nmdb-export-port-list --from-db --tcp`
@@ -331,7 +334,7 @@ intra-network:
         - title: nmap IPv4 DNS lookup, via open port 53
           cmd: clw nmap
           opts: &opts-nmap-dns-scan-intra
-          - -T4 -R -e {{linkName}} -sL --resolve-all
+          - -d -T4 -R -e {{linkName}} -sL --resolve-all
           - --dns-servers
           - $(cat
           - *path-possible-dns-servers
@@ -358,7 +361,7 @@ inter-network:
         - title: nmap IPv4 ICMP host discovery
           cmd: clw nmap
           opts:
-          - -T4 -n -e {{linkName}} -PR
+          - -d -T4 -n -e {{linkName}} -PR
           - -sn
           - -PE
           - -PP # ICMP Timestamp; not valid for IPv6
@@ -370,7 +373,7 @@ inter-network:
         - title: nmap IPv4 port discovery
           cmd: clw nmap
           opts: &opts-nmap-ipv4-port-discovery
-          - -T4 -n -e {{linkName}} -PR
+          - -d -T4 -n -e {{linkName}} -PR
           - -sn
           - "-PS\
             21-25,49,53,65,80,88,111,123,135-139,161-162,179,389,\
@@ -398,7 +401,7 @@ inter-network:
         - title: nmap IPv4 IP protocol scan
           cmd: clw nmap
           opts:
-          - -T4 -n -e {{linkName}} -PR
+          - -d -T4 -n -e {{linkName}} -PR
           - -sO
           - -iL
           - *path-roe-include-ips
@@ -408,7 +411,7 @@ inter-network:
         - title: nmap IPv6 ICMP host discovery
           cmd: clw nmap -6
           opts:
-          - -T4 -n -e {{linkName}} -PR
+          - -d -T4 -n -e {{linkName}} -PR
           - -sn
           - -PE
           - -iL
@@ -421,7 +424,7 @@ inter-network:
         - title: nmap IPv6 IP protocol scan
           cmd: clw nmap -6
           opts:
-          - -T4 -n -e {{linkName}} -PR
+          - -d -T4 -n -e {{linkName}} -PR
           - -sO
           - --script '(targets-ipv6-* or ipv6-node-info)'
             --script-args 'newtargets'
@@ -435,7 +438,7 @@ inter-network:
         - title: nmap IPv4 DNS lookup, default resolver
           cmd: clw nmap
           opts: &opts-nmap-ipv4-dns-intra
-          - -T4 -R -e {{linkName}} -sL --resolve-all
+          - -d -T4 -R -e {{linkName}} -sL --resolve-all
           - -iL
           - *path-roe-include-ips
           - --excludefile
@@ -451,7 +454,8 @@ inter-network:
         - title: nmap IPv4 TCP port scan
           cmd: clw nmap
           opts: &inter-opts-nmap-ipv4-tcp-port-scan
-          - -T4 -n -e {{linkName}} -PR
+          - -d -T4 -n -e {{linkName}} -PR
+          - --host-timeout 30m --script-timeout 5m
           - -Pn -O
           - --script
             '(banner or dns-nsid or ntp-info or rpcinfo
@@ -466,7 +470,8 @@ inter-network:
         - title: nmap IPv4 UDP port scan
           cmd: clw nmap
           opts: &inter-opts-nmap-ipv4-udp-port-scan
-          - -T4 -n -e {{linkName}} -PR
+          - -d -T4 -n -e {{linkName}} -PR
+          - --host-timeout 30m --script-timeout 2m
           - -Pn -O
           - --script
             '(banner or dns-nsid or ntp-info or rpcinfo
@@ -480,7 +485,7 @@ inter-network:
           - *path-roe-exclude-ips
         ipv6:
         - title: nmap IPv6 TCP port scan
-          cmd: clw nmap -6
+          cmd:  clw nmap -6
           opts: *inter-opts-nmap-ipv4-tcp-port-scan
         - title: nmap IPv6 UDP port scan
           cmd: clw nmap -6
@@ -492,7 +497,7 @@ inter-network:
         - title: nmap IPv4 DNS lookup, via open port 53
           cmd: clw nmap
           opts: &opts-nmap-dns-scan-inter
-          - -T4 -R -e {{linkName}} -sL --resolve-all
+          - -d -T4 -R -e {{linkName}} -sL --resolve-all
           - --dns-servers
           - $(cat
           - *path-possible-dns-servers


### PR DESCRIPTION
This resolves a few bugs I've encountered during usage that have crept in during recent dev commits as well an issue I was encountering with a tool.
- The `nmdb-import-ip-address` tool did not handle interface entries with `altname` lines; it should be fixed now (see around line 66).  Also added tests for the parser for the tool; nothing fancy, just something to verify I didn't change anything as I was going about it.  There looks like a lot of changes, but it was mainly organizational as I was having a hard time following it and disallowing roll-back because it hid the fact the parser was actually failing to parse correctly.
- Changes to the `nmdb-playbook` allowed for a multi-transaction instantiation instance; should be fixed now since I updated it to close out the transactions after the call (as they are read only anyway).
- Resolved an issue in the `CommandRunner` object where it was testing for non-zero (C++ success) instead of zero (POSIX success) for CLI based execution status.
- The ConTeXt export changes stopped printing lines between inter-network destination IPs.  I think that was a slip as the prior version did and nothing was stated that it was intentional.
- More quality of life/usage than anything, I updated the `plays.yaml` file to turn on debug for namp commands and to have host and script timeouts for slow hosts/scripts.  While the host timeout will kill very slow hosts, the script timeout is the one probably needed more.  Not sure which scripts are doing it, but basically it made my test scans (<20 hosts, ranging 2-30 ports) go from over 1.5 hrs (I manually killed it) to about 38 minutes.