### PR TITLE
Multi fix

### DIFF
--- a/datastore/exporters/nmdb-export-port-list/nmdb-export-port-list.cpp
+++ b/datastore/exporters/nmdb-export-port-list/nmdb-export-port-list.cpp
@@ -37,7 +37,7 @@ class Tool : public nmdt::AbstractExportTool
   protected:
     std::string portsStringFromBitset(std::bitset<65536> const& ports)
     {
-      std::string portsString;
+      std::ostringstream portsString;
 
       uint16_t portRangeFirst {0};
       uint16_t portRangeLast  {0};
@@ -58,17 +58,17 @@ class Tool : public nmdt::AbstractExportTool
             inPortRange = false;
 
             // Append the completed range onto the ports string.
-            portsString += std::to_string(static_cast<uint32_t>(portRangeFirst));
+            portsString << static_cast<uint32_t>(portRangeFirst);
             if (portRangeFirst < portRangeLast) {
-              portsString += "-";
-              portsString += std::to_string(static_cast<uint32_t>(portRangeLast));
+              portsString << "-";
+              portsString << static_cast<uint32_t>(portRangeLast);
             }
-            portsString += ",";
+            portsString << ",";
           }
         }
       }
 
-      return portsString;
+      return portsString.str();
     }
 
   public:
@@ -84,47 +84,48 @@ class Tool : public nmdt::AbstractExportTool
     void addToolOptions() override
     {
       opts.addOptionalOption("tcp", std::make_tuple(
-            "tcp,t",
-            NULL_SEMANTIC,
-            "Enable output of TCP ports from resource file or DB.")
-          );
+          "tcp,t",
+          NULL_SEMANTIC,
+          "Enable output of TCP ports from resource file or DB.")
+        );
       opts.addOptionalOption("tcp-all", std::make_tuple(
-            "tcp-all,T",
-            NULL_SEMANTIC,
-            "Enable output of TCP ports 0-65535.")
-          );
+          "tcp-all,T",
+          NULL_SEMANTIC,
+          "Enable output of TCP ports 0-65535.")
+        );
       opts.addOptionalOption("udp", std::make_tuple(
-            "udp,u",
-            NULL_SEMANTIC,
-            "Enable output of UDP ports from resource file or DB.")
-          );
+          "udp,u",
+          NULL_SEMANTIC,
+          "Enable output of UDP ports from resource file or DB.")
+        );
       opts.addOptionalOption("udp-all", std::make_tuple(
-            "udp-all,U",
-            NULL_SEMANTIC,
-            "Enable output of UDP ports 0-65535.")
-          );
+          "udp-all,U",
+          NULL_SEMANTIC,
+          "Enable output of UDP ports 0-65535.")
+        );
       opts.addOptionalOption("sctp", std::make_tuple(
-            "sctp,y",
-            NULL_SEMANTIC,
-            "Enable output of SCTP ports from resource file or DB.")
-          );
+          "sctp,y",
+          NULL_SEMANTIC,
+          "Enable output of SCTP ports from resource file or DB.")
+        );
       opts.addOptionalOption("stcp-all", std::make_tuple(
-            "sctp-all,Y",
-            NULL_SEMANTIC,
-            "Enable output of SCTP ports 0-65535.")
-          );
+          "sctp-all,Y",
+          NULL_SEMANTIC,
+          "Enable output of SCTP ports 0-65535.")
+        );
       opts.addOptionalOption("from-db", std::make_tuple(
-            "from-db,D",
-            NULL_SEMANTIC,
-            "Use ports from database instead of from resource file.")
-          );
+          "from-db,D",
+          NULL_SEMANTIC,
+          "Use ports from database instead of from resource file.")
+        );
 
       auto& nmfm {nmcu::FileManager::getInstance()};
       opts.addOptionalOption("config-path", std::make_tuple(
-            "config-path,c",
-            po::value<std::string>()->default_value(nmfm.getConfPath()/"port-list.conf"),
-            "Use specified port configuration file instead of the default.")
-          );
+          "config-path,c",
+          po::value<std::string>()
+            ->default_value(nmfm.getConfPath()/"port-list.conf"),
+          "Use specified port configuration file instead of the default.")
+        );
 
     }
 
@@ -235,16 +236,13 @@ class Tool : public nmdt::AbstractExportTool
 
       std::string nmapPorts;
       if (opts.exists("tcp") || opts.exists("tcp-all")) {
-        nmapPorts += "T:";
-        nmapPorts += portsStringFromBitset(tcpPorts);
+        nmapPorts += "T:" + portsStringFromBitset(tcpPorts);
       }
       if (opts.exists("udp") || opts.exists("udp-all")) {
-        nmapPorts += "U:";
-        nmapPorts += portsStringFromBitset(udpPorts);
+        nmapPorts += "U:" + portsStringFromBitset(udpPorts);
       }
       if (opts.exists("sctp") || opts.exists("sctp-all")) {
-        nmapPorts += "Y:";
-        nmapPorts += portsStringFromBitset(sctpPorts);
+        nmapPorts += "S:" + portsStringFromBitset(sctpPorts);
       }
       if (nmapPorts.size()) {
         nmapPorts.pop_back();  // Remove trailing ","
@@ -254,7 +252,6 @@ class Tool : public nmdt::AbstractExportTool
 
       return nmcu::Exit::SUCCESS;
     }
-
 };
 
 

--- a/datastore/graphers/nmdb-graph-network/README.md
+++ b/datastore/graphers/nmdb-graph-network/README.md
@@ -21,13 +21,22 @@ The *subnet* vertex will contain information (if it exists) such as:
 subnet, CIDR, VLAN ID, and network description.
 
 A solid edge between two vertices represents they are connected and can
-potentially communicate with each other (things like ACL rules are not
-considered here).
+potentially communicate with each other (concepts like ACL rules are not
+considered here).  In general, this solid edge represents that the device
+has a responding IP address within the connected subnet.  However, when
+the `responding-state` option is set to either `true` or `false` then
+the this does not hold and simply represents containment as responsive
+state is as asked for by the value of `responding-state`.
+
 A dashed edge represents one *device* is virtual and contained on another
 *device*, with the host being the vertex pointed to by the arrow.
 When the `--show-traceroute-hops` option is enabled, a dashed edge with a
-label `hop` will be applied to known routing paths as collected from
-traceroute activities.
+label `hop X to IP` (where `X` is a hop count; `IP` is an IP address)
+will be applied to known routing paths as collected from traceroute
+activities.
+
+IP or MAC addresses are color coded *green* in the cases where the Datasore
+shows them as responsive.
 
 
 ICONS
@@ -55,11 +64,19 @@ store, and rooted at the subnet `10.0.0.0/8`.
 nmdb-graph-network --layer 3 --device-id '10.0.0.0/8'
 ```
 
+Same as prior, but only show devices with a responding IP or MAC.  Note
+that, for a device, this will remove any IP and MAC pair which is not
+responding from the listing on the device as well.
+```
+nmdb-graph-network --layer 3 --device-id '10.0.0.0/8' --responding-state true
+```
+
 Generate `.dot` format output, with Layer-2 information contained in the data
 store, and rooted at the device with ID `core`.
 ```
 nmdb-graph-network --layer 2 --device-id core
 ```
+
 
 Directly produce a PDF or PNG version of a graph.
 ```

--- a/datastore/graphers/nmdb-graph-network/nmdb-graph-network.cpp
+++ b/datastore/graphers/nmdb-graph-network/nmdb-graph-network.cpp
@@ -432,7 +432,6 @@ class Tool : public nmdt::AbstractGraphTool
       removeEmptySubnets = opts.exists("no-empty-subnets");
       showTracerouteHops = opts.exists("show-traceroute-hops");
 
-      // "... = any($1)" -- '{t,f}', '{t}', '{f}'
       std::string state {opts.getValue("responding-state")};
       if ("0" == state || "true" == state) {
         respondingState = "{t}";

--- a/datastore/importers/nmdb-import-ip-addr-show/Parser.cpp
+++ b/datastore/importers/nmdb-import-ip-addr-show/Parser.cpp
@@ -55,13 +55,14 @@ Parser::Parser() : Parser::base_type(start)
     > qi::eol
 
     // link line
-    > qi::lit("link/")
-    > token [(pnx::bind(&nmdo::Interface::setMediaType, &qi::_val, qi::_1))]
-    > -macAddr [(pnx::bind(&nmdo::Interface::setMacAddress, &qi::_val, qi::_1))]
-    > -(qi::lit("brd") >> qi::omit[macAddr]
-        > -((+token) [(pnx::bind(&Parser::addObservation, this,
-                                 qi::_1, qi::_val))] ) )
-    > qi::eol
+    > -(qi::lit("link/")
+			> token [(pnx::bind(&nmdo::Interface::setMediaType, &qi::_val, qi::_1))]
+			> -macAddr [(pnx::bind(&nmdo::Interface::setMacAddress, &qi::_val, qi::_1))]
+			> -(qi::lit("brd") >> qi::omit[macAddr]
+					> -((+token) [(pnx::bind(&Parser::addObservation, this,
+																	 qi::_1, qi::_val))] ) )
+			> qi::eol
+		)
 
     // altname lines
     > *(qi::lit("altname") > token > qi::eol)

--- a/datastore/importers/nmdb-import-ip-addr-show/Parser.cpp
+++ b/datastore/importers/nmdb-import-ip-addr-show/Parser.cpp
@@ -56,13 +56,13 @@ Parser::Parser() : Parser::base_type(start)
 
     // link line
     > -(qi::lit("link/")
-			> token [(pnx::bind(&nmdo::Interface::setMediaType, &qi::_val, qi::_1))]
-			> -macAddr [(pnx::bind(&nmdo::Interface::setMacAddress, &qi::_val, qi::_1))]
-			> -(qi::lit("brd") >> qi::omit[macAddr]
-					> -((+token) [(pnx::bind(&Parser::addObservation, this,
-																	 qi::_1, qi::_val))] ) )
-			> qi::eol
-		)
+      > token [(pnx::bind(&nmdo::Interface::setMediaType, &qi::_val, qi::_1))]
+      > -macAddr [(pnx::bind(&nmdo::Interface::setMacAddress, &qi::_val, qi::_1))]
+      > -(qi::lit("brd") >> qi::omit[macAddr]
+          > -((+token) [(pnx::bind(&Parser::addObservation, this,
+                                   qi::_1, qi::_val))] ) )
+      > qi::eol
+    )
 
     // altname lines
     > *(qi::lit("altname") > token > qi::eol)

--- a/datastore/importers/nmdb-import-ip-addr-show/Parser.test.cpp
+++ b/datastore/importers/nmdb-import-ip-addr-show/Parser.test.cpp
@@ -126,10 +126,10 @@ BOOST_AUTO_TEST_CASE(testRules)
               inet6 fe80::1:1111:1:1/64 scope link 
                  valid_lft forever preferred_lft forever
 )"},
-			// ex `ip -6 addr show` (i.e., no link line when specify v4/6)
+      // ex `ip -6 addr show` (i.e., no link line when specify v4/6)
       {R"(1: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 state UP qlen 1000
-							inet6 1::2/64 scope link 
-								 valid_lft forever preferred_lft forever
+              inet6 1::2/64 scope link 
+                 valid_lft forever preferred_lft forever
 )"},
       {R"(255: t0: flags mtu 1 tokens
               link/type 00:11:22:33:44:55 brd ff:ff:ff:ff:ff:ff opt tokens

--- a/datastore/importers/nmdb-import-ip-addr-show/Parser.test.cpp
+++ b/datastore/importers/nmdb-import-ip-addr-show/Parser.test.cpp
@@ -126,6 +126,11 @@ BOOST_AUTO_TEST_CASE(testRules)
               inet6 fe80::1:1111:1:1/64 scope link 
                  valid_lft forever preferred_lft forever
 )"},
+			// ex `ip -6 addr show` (i.e., no link line when specify v4/6)
+      {R"(1: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 state UP qlen 1000
+							inet6 1::2/64 scope link 
+								 valid_lft forever preferred_lft forever
+)"},
       {R"(255: t0: flags mtu 1 tokens
               link/type 00:11:22:33:44:55 brd ff:ff:ff:ff:ff:ff opt tokens
               altname name1

--- a/datastore/inserters/nmdb-insert-address/nmdb-insert-address.cpp
+++ b/datastore/inserters/nmdb-insert-address/nmdb-insert-address.cpp
@@ -44,20 +44,20 @@ class Tool : public nmdt::AbstractInsertTool
     {
       //opts.addRequiredDeviceId();
       opts.addOptionalOption("device-id", std::make_tuple(
-            "device-id",
-            po::value<std::string>(),
-            "Name of device.")
-          );
+          "device-id",
+          po::value<std::string>(),
+          "Name of device.")
+        );
       opts.addOptionalOption("device-color", std::make_tuple(
-            "device-color",
-            po::value<std::string>(),
-            "Graph color of device.")
-          );
+          "device-color",
+          po::value<std::string>(),
+          "Graph color of device.")
+        );
       opts.addOptionalOption("device-type", std::make_tuple(
-            "device-type",
-            po::value<std::string>(),
-            "Type of device, determines graph icon.")
-          );
+          "device-type",
+          po::value<std::string>(),
+          "Type of device, determines graph icon.")
+        );
 
       opts.addOptionalOption("mac-addr", std::make_tuple(
           "mac-addr",
@@ -69,12 +69,17 @@ class Tool : public nmdt::AbstractInsertTool
           po::value<std::string>(),
           "IP address")
         );
+      opts.addOptionalOption("hostname", std::make_tuple(
+          "hostname",
+          po::value<std::string>(),
+          "Hostname or FQDN associated with IP address")
+        );
 
       opts.addOptionalOption("responding", std::make_tuple(
-            "responding",
-            po::value<bool>()->default_value(true),
-            "Set address to responding or not")
-          );
+          "responding",
+          po::value<bool>()->default_value(true),
+          "Set address to responding or not")
+        );
     }
 
     void
@@ -92,6 +97,9 @@ class Tool : public nmdt::AbstractInsertTool
       nmdo::IpAddress ipAddr;
       if (opts.exists("ip-addr")) {
         ipAddr = nmdo::IpAddress(opts.getValue("ip-addr"));
+        if (opts.exists("hostname")) {
+          ipAddr.addAlias(opts.getValue("hostname"), "insert-address");
+        }
       }
 
       macAddr.setResponding(isResponding);

--- a/datastore/inserters/nmdb-insert-device/nmdb-insert-device.cpp
+++ b/datastore/inserters/nmdb-insert-device/nmdb-insert-device.cpp
@@ -44,40 +44,45 @@ class Tool : public nmdt::AbstractInsertTool
       addRequiredDeviceId();
 
       opts.addOptionalOption("vm-host-device-id", std::make_tuple(
-            "vm-host-device-id",
-            po::value<std::string>(),
-            "Name of VM host device.")
-          );
+          "vm-host-device-id",
+          po::value<std::string>(),
+          "Name of VM host device.")
+        );
       opts.addOptionalOption("interface", std::make_tuple(
-            "interface",
-            po::value<std::string>(),
-            "Name of network interface.")
-          );
+          "interface",
+          po::value<std::string>(),
+          "Name of network interface.")
+        );
       opts.addOptionalOption("mediaType", std::make_tuple(
-            "mediaType",
-            po::value<std::string>()->default_value("ethernet"),
-            "Interface media type.")
-          );
+          "mediaType",
+          po::value<std::string>()->default_value("ethernet"),
+          "Interface media type.")
+        );
       opts.addOptionalOption("mac-addr", std::make_tuple(
-            "mac-addr",
-            po::value<std::string>(),
-            "MAC address of network interface.")
-          );
+          "mac-addr",
+          po::value<std::string>(),
+          "MAC address of network interface.")
+        );
       opts.addOptionalOption("ip-addr", std::make_tuple(
-            "ip-addr",
-            po::value<std::string>(),
-            "IP address of network interface.")
-          );
+          "ip-addr",
+          po::value<std::string>(),
+          "IP address of network interface.")
+        );
+      opts.addOptionalOption("hostname", std::make_tuple(
+          "hostname",
+          po::value<std::string>(),
+          "Hostname or FQDN associated with IP address")
+        );
       opts.addOptionalOption("responding", std::make_tuple(
-            "responding",
-            po::value<bool>()->default_value(true),
-            "Flag device as responding or not")
-          );
+          "responding",
+          po::value<bool>()->default_value(true),
+          "Flag device as responding or not")
+        );
       opts.addOptionalOption("low-graph-priority", std::make_tuple(
-            "low-graph-priority",
-            NULL_SEMANTIC,
-            "Device should be out-of-the-way (e.g. lower) in network graphs.")
-          );
+          "low-graph-priority",
+          NULL_SEMANTIC,
+          "Device should be out-of-the-way (e.g. lower) in network graphs.")
+        );
     }
 
     void
@@ -109,6 +114,9 @@ class Tool : public nmdt::AbstractInsertTool
       if (opts.exists("ip-addr")) {
         ipAddr = nmdo::IpAddress(opts.getValue("ip-addr"));
         ipAddr.setResponding(isResponding);
+        if (opts.exists("hostname")) {
+          ipAddr.addAlias(opts.getValue("hostname"), "insert-device");
+        }
 
         ipAddr.save(t, toolRunId, deviceId);
         LOG_DEBUG << ipAddr.toDebugString() << std::endl;


### PR DESCRIPTION
This PR resolves a few things, namely:
- Resolves #98: Changed `sctp` prefix to be as documented in `nmap` (that is an `S`).  The flag to generate it is still `Y` as that more closely follows `nmap` documentation as well.
- Resolves #107: Added a `responding-state` option.
  - It is set to `any` (from database perspective `t`, `f`, or `NULL`) by default but can take either a `true` or `false` value to alter behavior.  This will slightly alter behavior for some of the other options, however since this is new it shouldn't impact existing understanding of folks.
  - Also altered logic to color code "responding" IP/MAC addresses to a green color.  Updated documentation to reflect this as well.
- Fixed an issue with the `nmdb-import-ip-address` tool where it could not parse `ip -4 a s` or `ip -6 a s` type output.  Essentially, when the `inet` family flag is present, the link layer information is removed.
- Updated the `nmdb-insert-address` and `nmdb-insert-device` tooling to allow specifying alias/hostname/fqdn information for an IP.
