### PR TITLE
More Docker builds for Netmeld

### DIFF
--- a/Dockerfile-datalake-datastore
+++ b/Dockerfile-datalake-datastore
@@ -1,0 +1,140 @@
+FROM debian:testing-slim
+
+RUN apt update \
+ && apt install --assume-yes --no-install-recommends \
+      debconf \
+      build-essential \
+      cmake \
+      make \
+      gcc \
+      g++ \
+      git \
+      help2man \
+      pandoc \
+      libboost-date-time-dev \
+      libboost-iostreams-dev \
+      libboost-program-options-dev \
+      libboost-system-dev \
+      libboost-test-dev \
+      libpqxx-dev \
+      libpugixml-dev \
+      libpcap0.8-dev \
+      nlohmann-json3-dev \
+      libyaml-cpp-dev \
+ && apt install --assume-yes --no-install-recommends \
+      python3 \
+      apt-transport-https \
+      ca-certificates \
+ && rm -rf /var/lib/apt/lists/* \
+ && update-ca-certificates
+
+RUN groupadd -r netmeld \
+ && useradd -r -s /bin/false -g netmeld netmeld
+USER netmeld
+
+WORKDIR /home/netmeld
+
+RUN git clone https://github.com/netmeld/netmeld.git
+
+ENV cmakereplacement '# =============================================================================\n\
+# Copyright 2017 National Technology & Engineering Solutions of Sandia, LLC\n\
+# (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.\n\
+# Government retains certain rights in this software.\n\
+#\n\
+# Permission is hereby granted, free of charge, to any person obtaining a copy\n\
+# of this software and associated documentation files (the "Software"), to deal\n\
+# in the Software without restriction, including without limitation the rights\n\
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell\n\
+# copies of the Software, and to permit persons to whom the Software is\n\
+# furnished to do so, subject to the following conditions:\n\
+#\n\
+# The above copyright notice and this permission notice shall be included in\n\
+# all copies or substantial portions of the Software.\n\
+#\n\
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\n\
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\n\
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\n\
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\n\
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\n\
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\n\
+# SOFTWARE.\n\
+# =============================================================================\n\
+# Maintained by Sandia National Laboratories <Netmeld@sandia.gov>\n\
+# =============================================================================\n\
+\n\
+# ----------------------------------------------------------------------\n\
+# CMake Settings\n\
+# ----------------------------------------------------------------------\n\
+\n\
+cmake_minimum_required(VERSION 3.0)\n\
+#cmake_minimum_required(VERSION 3.13)\n\
+set(TOOL_SUITE "netmeld")\n\
+set(MODULE_NAME "netmeld")\n\
+project(${TOOL_SUITE})\n\
+\n\
+enable_testing()\n\
+\n\
+include(cmake/BuildEnvironment.cmake)\n\
+include(cmake/BuildHelpers.cmake)\n\
+\n\
+# ----------------------------------------------------------------------\n\
+# Libraries that many things need to link against for various reasons\n\
+# ----------------------------------------------------------------------\n\
+\n\
+find_package(Boost REQUIRED\n\
+  date_time\n\
+  iostreams\n\
+  program_options\n\
+  system\n\
+  unit_test_framework\n\
+  )\n\
+\n\
+find_package(nlohmann_json REQUIRED)\n\
+\n\
+find_package(yaml-cpp REQUIRED)\n\
+\n\
+# Appears to not be linked by default\n\
+link_libraries(stdc++fs)\n\
+\n\
+\n\
+# ----------------------------------------------------------------------\n\
+# Netmeld Configuration\n\
+# ----------------------------------------------------------------------\n\
+set(NETMELD_CONF_DIR "etc/netmeld")\n\
+set(NETMELD_DB_NAME "site")\n\
+set(NETMELD_SCHEMA_DIR "schemas")\n\
+set(NETMELD_IMAGE_DIR "images")\n\
+\n\
+add_compile_definitions(\n\
+  NETMELD_CONF_DIR="${CMAKE_INSTALL_PREFIX}/${NETMELD_CONF_DIR}"\n\
+  NETMELD_DB_NAME="${NETMELD_DB_NAME}"\n\
+  NETMELD_SCHEMA_DIR="${NETMELD_SCHEMA_DIR}"\n\
+  NETMELD_IMAGE_DIR="${NETMELD_IMAGE_DIR}"\n\
+  )\n\
+\n\
+set(TOOL_SUITE "netmeld")\n\
+add_custom_target(${TOOL_SUITE})\n\
+set(TEST_ALL "Test.${TOOL_SUITE}")\n\
+add_custom_target(${TEST_ALL})\n\
+\n\
+#create_man_from_readme(${TOOL_SUITE})\n\
+#install_man(${TOOL_SUITE} ${TOOL_SUITE})\n\
+\n\
+set(NETMELD_SOURCE_VERSION "2.0")\n\
+\n\
+foreach(ITEM\n\
+    core\n\
+    datalake\n\
+    datastore\n\
+  )\n\
+  target_as_module(${ITEM})\n\
+endforeach()\n\
+\n\
+include(cmake/PackageCreation.cmake)'
+
+RUN echo -n ${cmakereplacement} > netmeld/CMakeLists.txt \
+     && cd netmeld && echo dlds \
+     && cmake -S . -B ./build \
+     && cmake --build ./build
+
+ENV cmakereplacement ''

--- a/Dockerfile-fetchers
+++ b/Dockerfile-fetchers
@@ -1,0 +1,140 @@
+FROM debian:testing-slim
+
+RUN apt update \
+ && apt install --assume-yes --no-install-recommends \
+      debconf \
+      build-essential \
+      cmake \
+      make \
+      gcc \
+      g++ \
+      git \
+      help2man \
+      pandoc \
+      libboost-date-time-dev \
+      libboost-iostreams-dev \
+      libboost-program-options-dev \
+      libboost-system-dev \
+      libboost-test-dev \
+      libpqxx-dev \
+      libpugixml-dev \
+      libpcap0.8-dev \
+      nlohmann-json3-dev \
+      libyaml-cpp-dev \
+ && apt install --assume-yes --no-install-recommends \
+      python3 \
+      apt-transport-https \
+      ca-certificates \
+ && rm -rf /var/lib/apt/lists/* \
+ && update-ca-certificates
+
+RUN groupadd -r netmeld \
+ && useradd -r -s /bin/false -g netmeld netmeld
+USER netmeld
+
+WORKDIR /home/netmeld
+
+RUN git clone https://github.com/netmeld/netmeld.git
+
+ENV cmakereplacement '# =============================================================================\n\
+# Copyright 2017 National Technology & Engineering Solutions of Sandia, LLC\n\
+# (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.\n\
+# Government retains certain rights in this software.\n\
+#\n\
+# Permission is hereby granted, free of charge, to any person obtaining a copy\n\
+# of this software and associated documentation files (the "Software"), to deal\n\
+# in the Software without restriction, including without limitation the rights\n\
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell\n\
+# copies of the Software, and to permit persons to whom the Software is\n\
+# furnished to do so, subject to the following conditions:\n\
+#\n\
+# The above copyright notice and this permission notice shall be included in\n\
+# all copies or substantial portions of the Software.\n\
+#\n\
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\n\
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\n\
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\n\
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\n\
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\n\
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\n\
+# SOFTWARE.\n\
+# =============================================================================\n\
+# Maintained by Sandia National Laboratories <Netmeld@sandia.gov>\n\
+# =============================================================================\n\
+\n\
+# ----------------------------------------------------------------------\n\
+# CMake Settings\n\
+# ----------------------------------------------------------------------\n\
+\n\
+cmake_minimum_required(VERSION 3.0)\n\
+#cmake_minimum_required(VERSION 3.13)\n\
+set(TOOL_SUITE "netmeld")\n\
+set(MODULE_NAME "netmeld")\n\
+project(${TOOL_SUITE})\n\
+\n\
+enable_testing()\n\
+\n\
+include(cmake/BuildEnvironment.cmake)\n\
+include(cmake/BuildHelpers.cmake)\n\
+\n\
+# ----------------------------------------------------------------------\n\
+# Libraries that many things need to link against for various reasons\n\
+# ----------------------------------------------------------------------\n\
+\n\
+find_package(Boost REQUIRED\n\
+  date_time\n\
+  iostreams\n\
+  program_options\n\
+  system\n\
+  unit_test_framework\n\
+  )\n\
+\n\
+find_package(nlohmann_json REQUIRED)\n\
+\n\
+find_package(yaml-cpp REQUIRED)\n\
+\n\
+# Appears to not be linked by default\n\
+link_libraries(stdc++fs)\n\
+\n\
+\n\
+# ----------------------------------------------------------------------\n\
+# Netmeld Configuration\n\
+# ----------------------------------------------------------------------\n\
+set(NETMELD_CONF_DIR "etc/netmeld")\n\
+set(NETMELD_DB_NAME "site")\n\
+set(NETMELD_SCHEMA_DIR "schemas")\n\
+set(NETMELD_IMAGE_DIR "images")\n\
+\n\
+add_compile_definitions(\n\
+  NETMELD_CONF_DIR="${CMAKE_INSTALL_PREFIX}/${NETMELD_CONF_DIR}"\n\
+  NETMELD_DB_NAME="${NETMELD_DB_NAME}"\n\
+  NETMELD_SCHEMA_DIR="${NETMELD_SCHEMA_DIR}"\n\
+  NETMELD_IMAGE_DIR="${NETMELD_IMAGE_DIR}"\n\
+  )\n\
+\n\
+set(TOOL_SUITE "netmeld")\n\
+add_custom_target(${TOOL_SUITE})\n\
+set(TEST_ALL "Test.${TOOL_SUITE}")\n\
+add_custom_target(${TEST_ALL})\n\
+\n\
+#create_man_from_readme(${TOOL_SUITE})\n\
+#install_man(${TOOL_SUITE} ${TOOL_SUITE})\n\
+\n\
+set(NETMELD_SOURCE_VERSION "2.0")\n\
+\n\
+foreach(ITEM\n\
+    core\n\
+    fetchers\n\
+    tool-clw\n\
+  )\n\
+  target_as_module(${ITEM})\n\
+endforeach()\n\
+\n\
+include(cmake/PackageCreation.cmake)'
+
+RUN echo -n ${cmakereplacement} > netmeld/CMakeLists.txt \
+     && cd netmeld && echo fetchers \
+     && cmake -S . -B ./build \
+     && cmake --build ./build
+
+ENV cmakereplacement ''

--- a/Dockerfile-toolsuite
+++ b/Dockerfile-toolsuite
@@ -1,0 +1,40 @@
+FROM debian:testing-slim
+
+RUN apt update \
+ && apt install --assume-yes --no-install-recommends \
+      debconf \
+      build-essential \
+      cmake \
+      make \
+      gcc \
+      g++ \
+      git \
+      help2man \
+      pandoc \
+      libboost-date-time-dev \
+      libboost-iostreams-dev \
+      libboost-program-options-dev \
+      libboost-system-dev \
+      libboost-test-dev \
+      libpqxx-dev \
+      libpugixml-dev \
+      libpcap0.8-dev \
+      nlohmann-json3-dev \
+      libyaml-cpp-dev \
+ && apt install --assume-yes --no-install-recommends \
+      python3 \
+      apt-transport-https \
+      ca-certificates \
+ && rm -rf /var/lib/apt/lists/* \
+ && update-ca-certificates
+
+RUN groupadd -r netmeld \
+ && useradd -r -s /bin/false -g netmeld netmeld
+USER netmeld
+
+WORKDIR /home/netmeld
+
+RUN git clone https://github.com/netmeld/netmeld.git \
+     && cd netmeld && echo toolsuite \
+     && cmake -S . -B ./build \
+     && cmake --build ./build


### PR DESCRIPTION
Draft for Issue #96 
Currently untested, but I wanted to make sure the ideas are sound before I continue.

My thoughts were one image with the entire toolsuite, one image with the tools for fetching, and one image with the datalake and datastore, though the third one doesn't have psql setup yet. The playbook module is also only in the full toolsuite image and not one of its own.

I'm not yet sure on how the testing workflows could be handled. I've thought of building an image specifically for testing, but I'm unsure of it that would be enough.