### PR TITLE
Abstract parser types

### DIFF
--- a/datastore/common/tools/AbstractImportJsonTool.hpp
+++ b/datastore/common/tools/AbstractImportJsonTool.hpp
@@ -27,10 +27,7 @@
 #ifndef ABSTRACT_IMPORT_JSON_TOOL_HPP
 #define ABSTRACT_IMPORT_JSON_TOOL_HPP
 
-#include <netmeld/core/objects/Time.hpp>
-#include <netmeld/core/objects/Uuid.hpp>
-#include <netmeld/datastore/tools/AbstractDatastoreTool.hpp>
-#include <netmeld/datastore/objects/DeviceInformation.hpp>
+#include <netmeld/datastore/tools/AbstractImportTool.hpp>
 #include <nlohmann/json.hpp>
 
 namespace nmco = netmeld::core::objects;
@@ -42,22 +39,11 @@ using json = nlohmann::json;
 namespace netmeld::datastore::tools {
 
   template<typename TParser, typename TResults>
-  class AbstractImportJsonTool : public AbstractDatastoreTool
+  class AbstractImportJsonTool : public AbstractImportTool<TParser,TResults>
   {
     // =========================================================================
     // Variables
     // =========================================================================
-    private:
-      sfs::path   dataPath;
-
-    protected:
-      TResults    tResults;
-
-      nmco::Uuid  toolRunId;
-      nmco::Time  executionStart;
-      nmco::Time  executionStop;
-
-      nmdo::DeviceInformation devInfo;
 
 
     // =========================================================================
@@ -75,24 +61,7 @@ namespace netmeld::datastore::tools {
     // =========================================================================
     // Methods
     // =========================================================================
-    private:
-      // Performs default inserts into the DB
-      void generalInserts(pqxx::transaction_base&, const std::string&);
-      void addModuleOptions() override;
-
-    protected:
-      const sfs::path   getDataPath() const;
-      const std::string getDeviceId() const;
-      const nmco::Uuid  getToolRunId() const;
-      virtual void addToolOptions() override;
       virtual void parseData();
-      virtual void printHelp() const override;
-      virtual int  runTool() override;
-      virtual void setToolRunId();
-      // Tool specific behavior entry point
-      virtual void specificInserts(pqxx::transaction_base&);
-      // Tool run metadata behavior entry point
-      virtual void toolRunMetadataInserts(pqxx::transaction_base&);
   };
 }
 #include "AbstractImportJsonTool.ipp"

--- a/datastore/common/tools/AbstractImportJsonTool.hpp
+++ b/datastore/common/tools/AbstractImportJsonTool.hpp
@@ -1,0 +1,99 @@
+// =============================================================================
+// Copyright 2017 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// =============================================================================
+// Maintained by Sandia National Laboratories <Netmeld@sandia.gov>
+// =============================================================================
+
+#ifndef ABSTRACT_IMPORT_JSON_TOOL_HPP
+#define ABSTRACT_IMPORT_JSON_TOOL_HPP
+
+#include <netmeld/core/objects/Time.hpp>
+#include <netmeld/core/objects/Uuid.hpp>
+#include <netmeld/datastore/tools/AbstractDatastoreTool.hpp>
+#include <netmeld/datastore/objects/DeviceInformation.hpp>
+#include <nlohmann/json.hpp>
+
+namespace nmco = netmeld::core::objects;
+namespace nmdo = netmeld::datastore::objects;
+
+using json = nlohmann::json;
+
+
+namespace netmeld::datastore::tools {
+
+  template<typename TParser, typename TResults>
+  class AbstractImportJsonTool : public AbstractDatastoreTool
+  {
+    // =========================================================================
+    // Variables
+    // =========================================================================
+    private:
+      sfs::path   dataPath;
+
+    protected:
+      TResults    tResults;
+
+      nmco::Uuid  toolRunId;
+      nmco::Time  executionStart;
+      nmco::Time  executionStop;
+
+      nmdo::DeviceInformation devInfo;
+
+
+    // =========================================================================
+    // Constructors and Destructors
+    // =========================================================================
+    protected:
+      // Default constructor, provided only for convienence
+      AbstractImportJsonTool();
+      // Standard constructor, should be primary
+      AbstractImportJsonTool(const char*, const char*, const char*);
+
+    public:
+      virtual ~AbstractImportJsonTool() = default;
+
+    // =========================================================================
+    // Methods
+    // =========================================================================
+    private:
+      // Performs default inserts into the DB
+      void generalInserts(pqxx::transaction_base&, const std::string&);
+      void addModuleOptions() override;
+
+    protected:
+      const sfs::path   getDataPath() const;
+      const std::string getDeviceId() const;
+      const nmco::Uuid  getToolRunId() const;
+      virtual void addToolOptions() override;
+      virtual void parseData();
+      virtual void printHelp() const override;
+      virtual int  runTool() override;
+      virtual void setToolRunId();
+      // Tool specific behavior entry point
+      virtual void specificInserts(pqxx::transaction_base&);
+      // Tool run metadata behavior entry point
+      virtual void toolRunMetadataInserts(pqxx::transaction_base&);
+  };
+}
+#include "AbstractImportJsonTool.ipp"
+#endif // ABSTRACT_IMPORT_JSON_TOOL_HPP

--- a/datastore/common/tools/AbstractImportJsonTool.hpp
+++ b/datastore/common/tools/AbstractImportJsonTool.hpp
@@ -28,12 +28,9 @@
 #define ABSTRACT_IMPORT_JSON_TOOL_HPP
 
 #include <netmeld/datastore/tools/AbstractImportTool.hpp>
-#include <nlohmann/json.hpp>
 
 namespace nmco = netmeld::core::objects;
 namespace nmdo = netmeld::datastore::objects;
-
-using json = nlohmann::json;
 
 
 namespace netmeld::datastore::tools {

--- a/datastore/common/tools/AbstractImportJsonTool.ipp
+++ b/datastore/common/tools/AbstractImportJsonTool.ipp
@@ -128,9 +128,10 @@ namespace netmeld::datastore::tools {
           this->tResults = parser.getData();
       } catch (json::out_of_range& ex) {
           LOG_ERROR << "Parse error " << ex.what() << std::endl;
+          std::exit(nmcu::Exit::FAILURE);
       } catch (json::parse_error& ex) {
           LOG_ERROR << "Parse error at byte " << ex.byte << std::endl;
-          exit(1); // Error handling
+          std::exit(nmcu::Exit::FAILURE);
       }
       // end nmdb-import-aws copy
       executionStop = nmco::Time();

--- a/datastore/common/tools/AbstractImportJsonTool.ipp
+++ b/datastore/common/tools/AbstractImportJsonTool.ipp
@@ -1,0 +1,239 @@
+// =============================================================================
+// Copyright 2017 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// =============================================================================
+// Maintained by Sandia National Laboratories <Netmeld@sandia.gov>
+// =============================================================================
+
+// NOTE This implementation is included in the header (at the end) since it
+//      leverages templating.
+
+#include <netmeld/datastore/parsers/ParserHelper.hpp>
+#include <netmeld/datastore/utils/QueriesCommon.hpp>
+#include <nlohmann/json.hpp>
+
+namespace nmcu = netmeld::core::utils;
+namespace nmdp = netmeld::datastore::parsers;
+namespace nmdu = netmeld::datastore::utils;
+
+using json = nlohmann::json;
+
+
+namespace netmeld::datastore::tools {
+  // ===========================================================================
+  // Constructors
+  // ===========================================================================
+  template<typename P, typename R>
+  AbstractImportJsonTool<P,R>::AbstractImportJsonTool()
+  {}
+
+  template<typename P, typename R>
+  AbstractImportJsonTool<P,R>::AbstractImportJsonTool(
+      const char* _helpBlurb,
+      const char* _programName,
+      const char* _version) :
+    AbstractDatastoreTool(_helpBlurb, _programName, _version)
+  {}
+
+
+  // ===========================================================================
+  // Tool Entry Points (execution order)
+  // ===========================================================================
+  template<typename P, typename R>
+  int
+  AbstractImportJsonTool<P,R>::runTool()
+  {
+    if (opts.exists("data-path")) {
+      dataPath = sfs::canonical(opts.getValue("data-path"));
+    }
+
+    setToolRunId();
+
+    parseData(); // only returns on success
+
+    pqxx::connection db {getDbConnectString()};
+    nmdu::dbPrepareCommon(db);
+    pqxx::work t{db};
+
+    if (opts.exists("tool-run-metadata")) {
+      LOG_DEBUG << "Running as tool-run-metadata\n";
+      toolRunMetadataInserts(t);
+    }
+    else {
+      LOG_DEBUG << "Running as general/specific tool\n";
+      generalInserts(t, dataPath.string());
+      specificInserts(t);
+    }
+
+    t.commit();
+
+    if (!opts.exists("tool-run-id")) {
+      LOG_INFO << "tool-run-id: " << toolRunId << '\n';
+    }
+
+    return nmcu::Exit::SUCCESS;
+  }
+
+  template<typename P, typename R>
+  void
+  AbstractImportJsonTool<P,R>::printHelp() const
+  {
+    LOG_NOTICE << "Import output from " << helpBlurb
+               << "\nUsage: " << programName << " [options] DATA_PATH"
+               << "\nOptions:\n"
+               << opts
+               << this->bugTeam
+               << '\n';
+  }
+
+  template<typename P, typename R>
+  void
+  AbstractImportJsonTool<P,R>::setToolRunId()
+  {
+    toolRunId
+      = opts.exists("tool-run-id")
+      ? (nmco::Uuid(opts.getValue("tool-run-id")))
+      : (nmco::Uuid());
+  }
+
+  template<typename P,typename R>
+  void
+  AbstractImportJsonTool<P,R>::parseData()
+  {
+      executionStart = nmco::Time();
+      // How it's done in nmdb-import-aws...
+      try {
+          P parser;
+          std::ifstream f {this->getDataPath().string()};
+          parser.fromJson(json::parse(f));
+          this->tResults = parser.getData();
+      } catch (json::out_of_range& ex) {
+          LOG_ERROR << "Parse error " << ex.what() << std::endl;
+      } catch (json::parse_error& ex) {
+          LOG_ERROR << "Parse error at byte " << ex.byte << std::endl;
+          exit(1); // Error handling
+      }
+      // end nmdb-import-aws copy
+      executionStop = nmco::Time();
+  }
+
+  template<typename P, typename R>
+  void
+  AbstractImportJsonTool<P,R>::toolRunMetadataInserts(pqxx::transaction_base&)
+  {}
+
+  template<typename P, typename R>
+  void
+  AbstractImportJsonTool<P,R>::specificInserts(pqxx::transaction_base&)
+  {}
+
+  template<typename P, typename R>
+  void
+  AbstractImportJsonTool<P,R>::addModuleOptions()
+  {
+    AbstractDatastoreTool::addModuleOptions();
+
+    addRequiredDeviceId();
+
+    opts.addRequiredOption("data-path", std::make_tuple(
+          "data-path",
+          po::value<std::string>()->required(),
+          "Data to parse. Either --data-path param or implicit last argument.")
+        );
+
+    opts.addOptionalOption("pipe", std::make_tuple(
+          "pipe",
+          NULL_SEMANTIC,
+          "Read input from STDIN; Save a copy to DATA_PATH for parsing.")
+        );
+
+    opts.addAdvancedOption("tool-run-id", std::make_tuple(
+          "tool-run-id",
+          po::value<std::string>(),
+          "UUID for this run of the tool.")
+        );
+    opts.addAdvancedOption("tool-run-metadata", std::make_tuple(
+          "tool-run-metadata",
+          NULL_SEMANTIC,
+          "Insert data into tool_run tables instead of device tables.")
+        );
+
+    opts.addPositionalOption("data-path", -1);
+  }
+
+  template<typename P, typename R>
+  void
+  AbstractImportJsonTool<P,R>::addToolOptions()
+  {}
+
+
+  // ===========================================================================
+  // General Functions (alphabetical)
+  // ===========================================================================
+  template<typename P, typename R>
+  void
+  AbstractImportJsonTool<P,R>::generalInserts(
+      pqxx::transaction_base& t,
+      const std::string& dataFile)
+  {
+    t.exec_prepared("insert_tool_run",
+        toolRunId,
+        programName,
+        helpBlurb, // commandLine
+        dataFile,
+        executionStart,
+        executionStop);
+
+    if (opts.exists("device-id")) {
+      devInfo.setDeviceId(opts.getValue("device-id"));
+    }
+    if (opts.exists("device-type")) {
+      devInfo.setDeviceType(opts.getValue("device-type"));
+    }
+    if (opts.exists("device-color")) {
+      devInfo.setDeviceColor(opts.getValue("device-color"));
+    }
+
+    devInfo.save(t, toolRunId);
+  }
+
+  template<typename P, typename R>
+  sfs::path const
+  AbstractImportJsonTool<P,R>::getDataPath() const
+  {
+    return dataPath;
+  }
+
+  template<typename P, typename R>
+  const std::string
+  AbstractImportJsonTool<P,R>::getDeviceId() const
+  {
+    return devInfo.getDeviceId();
+  }
+
+  template<typename P, typename R>
+  nmco::Uuid const
+  AbstractImportJsonTool<P,R>::getToolRunId() const
+  {
+    return toolRunId;
+  }
+}

--- a/datastore/common/tools/AbstractImportJsonTool.ipp
+++ b/datastore/common/tools/AbstractImportJsonTool.ipp
@@ -51,76 +51,19 @@ namespace netmeld::datastore::tools {
       const char* _helpBlurb,
       const char* _programName,
       const char* _version) :
-    AbstractDatastoreTool(_helpBlurb, _programName, _version)
+    AbstractImportTool<P,R>(_helpBlurb, _programName, _version)
   {}
 
 
   // ===========================================================================
   // Tool Entry Points (execution order)
   // ===========================================================================
-  template<typename P, typename R>
-  int
-  AbstractImportJsonTool<P,R>::runTool()
-  {
-    if (opts.exists("data-path")) {
-      dataPath = sfs::canonical(opts.getValue("data-path"));
-    }
-
-    setToolRunId();
-
-    parseData(); // only returns on success
-
-    pqxx::connection db {getDbConnectString()};
-    nmdu::dbPrepareCommon(db);
-    pqxx::work t{db};
-
-    if (opts.exists("tool-run-metadata")) {
-      LOG_DEBUG << "Running as tool-run-metadata\n";
-      toolRunMetadataInserts(t);
-    }
-    else {
-      LOG_DEBUG << "Running as general/specific tool\n";
-      generalInserts(t, dataPath.string());
-      specificInserts(t);
-    }
-
-    t.commit();
-
-    if (!opts.exists("tool-run-id")) {
-      LOG_INFO << "tool-run-id: " << toolRunId << '\n';
-    }
-
-    return nmcu::Exit::SUCCESS;
-  }
-
-  template<typename P, typename R>
-  void
-  AbstractImportJsonTool<P,R>::printHelp() const
-  {
-    LOG_NOTICE << "Import output from " << helpBlurb
-               << "\nUsage: " << programName << " [options] DATA_PATH"
-               << "\nOptions:\n"
-               << opts
-               << this->bugTeam
-               << '\n';
-  }
-
-  template<typename P, typename R>
-  void
-  AbstractImportJsonTool<P,R>::setToolRunId()
-  {
-    toolRunId
-      = opts.exists("tool-run-id")
-      ? (nmco::Uuid(opts.getValue("tool-run-id")))
-      : (nmco::Uuid());
-  }
 
   template<typename P,typename R>
   void
   AbstractImportJsonTool<P,R>::parseData()
   {
-      executionStart = nmco::Time();
-      // How it's done in nmdb-import-aws...
+      this->executionStart = nmco::Time();
       try {
           P parser;
           std::ifstream f {this->getDataPath().string()};
@@ -133,108 +76,6 @@ namespace netmeld::datastore::tools {
           LOG_ERROR << "Parse error at byte " << ex.byte << std::endl;
           std::exit(nmcu::Exit::FAILURE);
       }
-      // end nmdb-import-aws copy
-      executionStop = nmco::Time();
-  }
-
-  template<typename P, typename R>
-  void
-  AbstractImportJsonTool<P,R>::toolRunMetadataInserts(pqxx::transaction_base&)
-  {}
-
-  template<typename P, typename R>
-  void
-  AbstractImportJsonTool<P,R>::specificInserts(pqxx::transaction_base&)
-  {}
-
-  template<typename P, typename R>
-  void
-  AbstractImportJsonTool<P,R>::addModuleOptions()
-  {
-    AbstractDatastoreTool::addModuleOptions();
-
-    addRequiredDeviceId();
-
-    opts.addRequiredOption("data-path", std::make_tuple(
-          "data-path",
-          po::value<std::string>()->required(),
-          "Data to parse. Either --data-path param or implicit last argument.")
-        );
-
-    opts.addOptionalOption("pipe", std::make_tuple(
-          "pipe",
-          NULL_SEMANTIC,
-          "Read input from STDIN; Save a copy to DATA_PATH for parsing.")
-        );
-
-    opts.addAdvancedOption("tool-run-id", std::make_tuple(
-          "tool-run-id",
-          po::value<std::string>(),
-          "UUID for this run of the tool.")
-        );
-    opts.addAdvancedOption("tool-run-metadata", std::make_tuple(
-          "tool-run-metadata",
-          NULL_SEMANTIC,
-          "Insert data into tool_run tables instead of device tables.")
-        );
-
-    opts.addPositionalOption("data-path", -1);
-  }
-
-  template<typename P, typename R>
-  void
-  AbstractImportJsonTool<P,R>::addToolOptions()
-  {}
-
-
-  // ===========================================================================
-  // General Functions (alphabetical)
-  // ===========================================================================
-  template<typename P, typename R>
-  void
-  AbstractImportJsonTool<P,R>::generalInserts(
-      pqxx::transaction_base& t,
-      const std::string& dataFile)
-  {
-    t.exec_prepared("insert_tool_run",
-        toolRunId,
-        programName,
-        helpBlurb, // commandLine
-        dataFile,
-        executionStart,
-        executionStop);
-
-    if (opts.exists("device-id")) {
-      devInfo.setDeviceId(opts.getValue("device-id"));
-    }
-    if (opts.exists("device-type")) {
-      devInfo.setDeviceType(opts.getValue("device-type"));
-    }
-    if (opts.exists("device-color")) {
-      devInfo.setDeviceColor(opts.getValue("device-color"));
-    }
-
-    devInfo.save(t, toolRunId);
-  }
-
-  template<typename P, typename R>
-  sfs::path const
-  AbstractImportJsonTool<P,R>::getDataPath() const
-  {
-    return dataPath;
-  }
-
-  template<typename P, typename R>
-  const std::string
-  AbstractImportJsonTool<P,R>::getDeviceId() const
-  {
-    return devInfo.getDeviceId();
-  }
-
-  template<typename P, typename R>
-  nmco::Uuid const
-  AbstractImportJsonTool<P,R>::getToolRunId() const
-  {
-    return toolRunId;
+      this->executionStop = nmco::Time();
   }
 }

--- a/datastore/common/tools/AbstractImportSpiritTool.hpp
+++ b/datastore/common/tools/AbstractImportSpiritTool.hpp
@@ -24,11 +24,10 @@
 // Maintained by Sandia National Laboratories <Netmeld@sandia.gov>
 // =============================================================================
 
-#ifndef ABSTRACT_IMPORT_XML_TOOL_HPP
-#define ABSTRACT_IMPORT_XML_TOOL_HPP
+#ifndef ABSTRACT_IMPORT_SPIRIT_TOOL_HPP
+#define ABSTRACT_IMPORT_SPIRIT_TOOL_HPP
 
 #include <netmeld/datastore/tools/AbstractImportTool.hpp>
-#include <pugixml.hpp>
 
 namespace nmco = netmeld::core::objects;
 namespace nmdo = netmeld::datastore::objects;
@@ -37,31 +36,31 @@ namespace nmdo = netmeld::datastore::objects;
 namespace netmeld::datastore::tools {
 
   template<typename TParser, typename TResults>
-  class AbstractImportXMLTool : public AbstractImportTool<TParser,TResults>
+  class AbstractImportSpiritTool : public AbstractImportTool<TParser,TResults>
   {
     // =========================================================================
     // Variables
     // =========================================================================
-
 
     // =========================================================================
     // Constructors and Destructors
     // =========================================================================
     protected:
       // Default constructor, provided only for convienence
-      AbstractImportXMLTool();
+      AbstractImportSpiritTool();
       // Standard constructor, should be primary
-      AbstractImportXMLTool(const char*, const char*, const char*);
+      AbstractImportSpiritTool(const char*, const char*, const char*);
 
     public:
-      virtual ~AbstractImportXMLTool() = default;
+      virtual ~AbstractImportSpiritTool() = default;
 
     // =========================================================================
     // Methods
     // =========================================================================
+
     protected:
       virtual void parseData();
   };
 }
-#include "AbstractImportXMLTool.ipp"
-#endif // ABSTRACT_IMPORT_XML_TOOL_HPP
+#include "AbstractImportSpiritTool.ipp"
+#endif // ABSTRACT_IMPORT_SPIRIT_TOOL_HPP

--- a/datastore/common/tools/AbstractImportSpiritTool.ipp
+++ b/datastore/common/tools/AbstractImportSpiritTool.ipp
@@ -24,44 +24,43 @@
 // Maintained by Sandia National Laboratories <Netmeld@sandia.gov>
 // =============================================================================
 
-#ifndef ABSTRACT_IMPORT_XML_TOOL_HPP
-#define ABSTRACT_IMPORT_XML_TOOL_HPP
+// NOTE This implementation is included in the header (at the end) since it
+//      leverages templating.
 
-#include <netmeld/datastore/tools/AbstractImportTool.hpp>
-#include <pugixml.hpp>
+#include <netmeld/datastore/parsers/ParserHelper.hpp>
+#include <netmeld/datastore/utils/QueriesCommon.hpp>
 
-namespace nmco = netmeld::core::objects;
-namespace nmdo = netmeld::datastore::objects;
-
+namespace nmcu = netmeld::core::utils;
+namespace nmdp = netmeld::datastore::parsers;
+namespace nmdu = netmeld::datastore::utils;
 
 namespace netmeld::datastore::tools {
+  // ===========================================================================
+  // Constructors
+  // ===========================================================================
+  template<typename P, typename R>
+  AbstractImportSpiritTool<P,R>::AbstractImportSpiritTool()
+  {}
 
-  template<typename TParser, typename TResults>
-  class AbstractImportXMLTool : public AbstractImportTool<TParser,TResults>
+  template<typename P, typename R>
+  AbstractImportSpiritTool<P,R>::AbstractImportSpiritTool(
+      const char* _helpBlurb,
+      const char* _programName,
+      const char* _version) :
+    AbstractImportTool<P,R>(_helpBlurb, _programName, _version)
+  {}
+
+
+  // ===========================================================================
+  // Tool Entry Points (execution order)
+  // ===========================================================================
+
+  template<typename P, typename R>
+  void
+  AbstractImportSpiritTool<P,R>::parseData() // Could pass the parser as an argument
   {
-    // =========================================================================
-    // Variables
-    // =========================================================================
-
-
-    // =========================================================================
-    // Constructors and Destructors
-    // =========================================================================
-    protected:
-      // Default constructor, provided only for convienence
-      AbstractImportXMLTool();
-      // Standard constructor, should be primary
-      AbstractImportXMLTool(const char*, const char*, const char*);
-
-    public:
-      virtual ~AbstractImportXMLTool() = default;
-
-    // =========================================================================
-    // Methods
-    // =========================================================================
-    protected:
-      virtual void parseData();
-  };
+    this->executionStart = nmco::Time();
+    this->tResults = nmdp::fromFilePath<P,R>(this->dataPath.string());
+    this->executionStop = nmco::Time();
+  }
 }
-#include "AbstractImportXMLTool.ipp"
-#endif // ABSTRACT_IMPORT_XML_TOOL_HPP

--- a/datastore/common/tools/AbstractImportTool.hpp
+++ b/datastore/common/tools/AbstractImportTool.hpp
@@ -44,10 +44,9 @@ namespace netmeld::datastore::tools {
     // =========================================================================
     // Variables
     // =========================================================================
-    private:
-      sfs::path   dataPath;
 
     protected:
+      sfs::path   dataPath;
       TResults    tResults;
 
       nmco::Uuid  toolRunId;
@@ -82,7 +81,7 @@ namespace netmeld::datastore::tools {
       const std::string getDeviceId() const;
       const nmco::Uuid  getToolRunId() const;
       virtual void addToolOptions() override;
-      virtual void parseData();
+      virtual void parseData() = 0;
       virtual void printHelp() const override;
       virtual int  runTool() override;
       virtual void setToolRunId();

--- a/datastore/common/tools/AbstractImportTool.ipp
+++ b/datastore/common/tools/AbstractImportTool.ipp
@@ -113,15 +113,6 @@ namespace netmeld::datastore::tools {
 
   template<typename P, typename R>
   void
-  AbstractImportTool<P,R>::parseData() // Could pass the parser as an argument
-  {
-    executionStart = nmco::Time();
-    tResults = nmdp::fromFilePath<P,R>(dataPath.string());
-    executionStop = nmco::Time();
-  }
-
-  template<typename P, typename R>
-  void
   AbstractImportTool<P,R>::toolRunMetadataInserts(pqxx::transaction_base&)
   {}
 

--- a/datastore/common/tools/AbstractImportXMLTool.hpp
+++ b/datastore/common/tools/AbstractImportXMLTool.hpp
@@ -1,0 +1,94 @@
+// =============================================================================
+// Copyright 2017 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// =============================================================================
+// Maintained by Sandia National Laboratories <Netmeld@sandia.gov>
+// =============================================================================
+
+#ifndef ABSTRACT_IMPORT_JSON_TOOL_HPP
+#define ABSTRACT_IMPORT_JSON_TOOL_HPP
+
+#include <netmeld/core/objects/Time.hpp>
+#include <netmeld/core/objects/Uuid.hpp>
+#include <netmeld/datastore/tools/AbstractDatastoreTool.hpp>
+#include <netmeld/datastore/objects/DeviceInformation.hpp>
+#include <pugixml.hpp>
+
+namespace nmco = netmeld::core::objects;
+namespace nmdo = netmeld::datastore::objects;
+
+
+namespace netmeld::datastore::tools {
+
+  template<typename TParser, typename TResults>
+  class AbstractImportXMLTool : public AbstractDatastoreTool
+  {
+    // =========================================================================
+    // Variables
+    // =========================================================================
+    private:
+      sfs::path   dataPath;
+
+    protected:
+      TResults    tResults;
+
+      nmco::Uuid  toolRunId;
+      nmco::Time  executionStart;
+      nmco::Time  executionStop;
+
+      nmdo::DeviceInformation devInfo;
+
+
+    // =========================================================================
+    // Constructors and Destructors
+    // =========================================================================
+    protected:
+      // Default constructor, provided only for convienence
+      AbstractImportXMLTool();
+      // Standard constructor, should be primary
+      AbstractImportXMLTool(const char*, const char*, const char*);
+
+    public:
+      virtual ~AbstractImportXMLTool() = default;
+
+    // =========================================================================
+    // Methods
+    // =========================================================================
+    private:
+      // Performs default inserts into the DB
+      void generalInserts(pqxx::transaction_base&, const std::string&);
+      void addModuleOptions() override;
+
+    protected:
+      const sfs::path   getDataPath() const;
+      const std::string getDeviceId() const;
+      const nmco::Uuid  getToolRunId() const;
+      virtual void addToolOptions() override;
+      virtual void parseData();
+      // Tool specific behavior entry point
+      virtual void specificInserts(pqxx::transaction_base&);
+      // Tool run metadata behavior entry point
+      virtual void toolRunMetadataInserts(pqxx::transaction_base&);
+  };
+}
+#include "AbstractImportXMLTool.ipp"
+#endif // ABSTRACT_IMPORT_JSON_TOOL_HPP

--- a/datastore/common/tools/AbstractImportXMLTool.ipp
+++ b/datastore/common/tools/AbstractImportXMLTool.ipp
@@ -29,7 +29,6 @@
 
 #include <netmeld/datastore/parsers/ParserHelper.hpp>
 #include <netmeld/datastore/utils/QueriesCommon.hpp>
-#include <nlohmann/json.hpp>
 
 namespace nmcu = netmeld::core::utils;
 namespace nmdp = netmeld::datastore::parsers;
@@ -51,7 +50,7 @@ namespace netmeld::datastore::tools {
       const char* _helpBlurb,
       const char* _programName,
       const char* _version) :
-    AbstractDatastoreTool(_helpBlurb, _programName, _version)
+    AbstractImportTool<P,R>(_helpBlurb, _programName, _version)
   {}
 
 
@@ -63,8 +62,7 @@ namespace netmeld::datastore::tools {
   void
   AbstractImportXMLTool<P,R>::parseData()
   {
-      executionStart = nmco::Time();
-      // How it's done in nmdb-import-juniper-xml
+      this->executionStart = nmco::Time();
       pugi::xml_document doc;
        if (!doc.load_file(this->getDataPath().string().c_str(),
                          pugi::parse_default | pugi::parse_trim_pcdata)) {
@@ -75,109 +73,7 @@ namespace netmeld::datastore::tools {
       }
       P parser;
       parser.handleXML(doc);
-      this->tResults = parser.getData(); // emplace_back was used in nmdb-import-juniper-xml
-      // end nmdb-import-juniper-xml
-      executionStop = nmco::Time();
-  }
-
-  template<typename P, typename R>
-  void
-  AbstractImportXMLTool<P,R>::toolRunMetadataInserts(pqxx::transaction_base&)
-  {}
-
-  template<typename P, typename R>
-  void
-  AbstractImportXMLTool<P,R>::specificInserts(pqxx::transaction_base&)
-  {}
-
-  template<typename P, typename R>
-  void
-  AbstractImportXMLTool<P,R>::addModuleOptions()
-  {
-    AbstractDatastoreTool::addModuleOptions();
-
-    addRequiredDeviceId();
-
-    opts.addRequiredOption("data-path", std::make_tuple(
-          "data-path",
-          po::value<std::string>()->required(),
-          "Data to parse. Either --data-path param or implicit last argument.")
-        );
-
-    opts.addOptionalOption("pipe", std::make_tuple(
-          "pipe",
-          NULL_SEMANTIC,
-          "Read input from STDIN; Save a copy to DATA_PATH for parsing.")
-        );
-
-    opts.addAdvancedOption("tool-run-id", std::make_tuple(
-          "tool-run-id",
-          po::value<std::string>(),
-          "UUID for this run of the tool.")
-        );
-    opts.addAdvancedOption("tool-run-metadata", std::make_tuple(
-          "tool-run-metadata",
-          NULL_SEMANTIC,
-          "Insert data into tool_run tables instead of device tables.")
-        );
-
-    opts.addPositionalOption("data-path", -1);
-  }
-
-  template<typename P, typename R>
-  void
-  AbstractImportXMLTool<P,R>::addToolOptions()
-  {}
-
-
-  // ===========================================================================
-  // General Functions (alphabetical)
-  // ===========================================================================
-  template<typename P, typename R>
-  void
-  AbstractImportXMLTool<P,R>::generalInserts(
-      pqxx::transaction_base& t,
-      const std::string& dataFile)
-  {
-    t.exec_prepared("insert_tool_run",
-        toolRunId,
-        programName,
-        helpBlurb, // commandLine
-        dataFile,
-        executionStart,
-        executionStop);
-
-    if (opts.exists("device-id")) {
-      devInfo.setDeviceId(opts.getValue("device-id"));
-    }
-    if (opts.exists("device-type")) {
-      devInfo.setDeviceType(opts.getValue("device-type"));
-    }
-    if (opts.exists("device-color")) {
-      devInfo.setDeviceColor(opts.getValue("device-color"));
-    }
-
-    devInfo.save(t, toolRunId);
-  }
-
-  template<typename P, typename R>
-  sfs::path const
-  AbstractImportXMLTool<P,R>::getDataPath() const
-  {
-    return dataPath;
-  }
-
-  template<typename P, typename R>
-  const std::string
-  AbstractImportXMLTool<P,R>::getDeviceId() const
-  {
-    return devInfo.getDeviceId();
-  }
-
-  template<typename P, typename R>
-  nmco::Uuid const
-  AbstractImportXMLTool<P,R>::getToolRunId() const
-  {
-    return toolRunId;
+      this->tResults = parser.getData();
+      this->executionStop = nmco::Time();
   }
 }

--- a/datastore/common/tools/AbstractImportXmlTool.hpp
+++ b/datastore/common/tools/AbstractImportXmlTool.hpp
@@ -28,7 +28,6 @@
 #define ABSTRACT_IMPORT_XML_TOOL_HPP
 
 #include <netmeld/datastore/tools/AbstractImportTool.hpp>
-#include <pugixml.hpp>
 
 namespace nmco = netmeld::core::objects;
 namespace nmdo = netmeld::datastore::objects;
@@ -37,7 +36,7 @@ namespace nmdo = netmeld::datastore::objects;
 namespace netmeld::datastore::tools {
 
   template<typename TParser, typename TResults>
-  class AbstractImportXMLTool : public AbstractImportTool<TParser,TResults>
+  class AbstractImportXmlTool : public AbstractImportTool<TParser,TResults>
   {
     // =========================================================================
     // Variables
@@ -49,12 +48,12 @@ namespace netmeld::datastore::tools {
     // =========================================================================
     protected:
       // Default constructor, provided only for convienence
-      AbstractImportXMLTool();
+      AbstractImportXmlTool();
       // Standard constructor, should be primary
-      AbstractImportXMLTool(const char*, const char*, const char*);
+      AbstractImportXmlTool(const char*, const char*, const char*);
 
     public:
-      virtual ~AbstractImportXMLTool() = default;
+      virtual ~AbstractImportXmlTool() = default;
 
     // =========================================================================
     // Methods
@@ -63,5 +62,5 @@ namespace netmeld::datastore::tools {
       virtual void parseData();
   };
 }
-#include "AbstractImportXMLTool.ipp"
+#include "AbstractImportXmlTool.ipp"
 #endif // ABSTRACT_IMPORT_XML_TOOL_HPP

--- a/datastore/common/tools/AbstractImportXmlTool.ipp
+++ b/datastore/common/tools/AbstractImportXmlTool.ipp
@@ -42,11 +42,11 @@ namespace netmeld::datastore::tools {
   // Constructors
   // ===========================================================================
   template<typename P, typename R>
-  AbstractImportXMLTool<P,R>::AbstractImportXMLTool()
+  AbstractImportXmlTool<P,R>::AbstractImportXmlTool()
   {}
 
   template<typename P, typename R>
-  AbstractImportXMLTool<P,R>::AbstractImportXMLTool(
+  AbstractImportXmlTool<P,R>::AbstractImportXmlTool(
       const char* _helpBlurb,
       const char* _programName,
       const char* _version) :
@@ -60,7 +60,7 @@ namespace netmeld::datastore::tools {
 
   template<typename P,typename R>
   void
-  AbstractImportXMLTool<P,R>::parseData()
+  AbstractImportXmlTool<P,R>::parseData()
   {
       this->executionStart = nmco::Time();
       pugi::xml_document doc;

--- a/datastore/importers/import-tool-template/import-tool-template.cpp
+++ b/datastore/importers/import-tool-template/import-tool-template.cpp
@@ -44,7 +44,7 @@
    - Parser logic should be separate
 */
 
-#include <netmeld/datastore/tools/AbstractImportTool.hpp>
+#include <netmeld/datastore/tools/AbstractImportSpiritTool.hpp>
 #include <netmeld/datastore/parsers/ParserHelper.hpp> // if parser not needed
 
 #include "Parser.hpp"
@@ -58,7 +58,7 @@ namespace nmdt = netmeld::datastore::tools;
 // Import tool definition
 // =============================================================================
 template<typename P, typename R>
-class Tool : public nmdt::AbstractImportTool<P,R>
+class Tool : public nmdt::AbstractImportSpiritTool<P,R>
 {
   // ===========================================================================
   // Variables
@@ -70,7 +70,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
       // std::string            programName;
       // std::string            version;
       // ProgramOptions         opts;
-    // Inhertied from AbstractImportTool at this scope
+    // Inhertied from AbstractImportSpiritTool at this scope
       // TResults                 tResults;
       // nmco::Uuid               toolRunId;
       // nmco::Time               executionStart;
@@ -85,7 +85,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
   private: // Constructors should rarely appear at this scope
   protected: // Constructors intended for internal/subclass API
   public: // Constructors should generally be public
-    Tool() : nmdt::AbstractImportTool<P,R>
+    Tool() : nmdt::AbstractImportSpiritTool<P,R>
       (
        "some-command --flag",  // command line tool imports data from
        PROGRAM_NAME,           // program name (set in CMakeLists.txt)
@@ -98,7 +98,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
   // Methods
   // ===========================================================================
   private: // Methods part of internal API
-    // Overriden from AbstractImportTool
+    // Overriden from AbstractImportSpiritTool
     void
     addToolOptions() override
     {
@@ -112,7 +112,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
       this->opts.removeAdvancedOption("tool-run-metadata");
     }
 
-    // Overriden from AbstractImportTool
+    // Overriden from AbstractImportSpiritTool
     void
     specificInserts(pqxx::transaction_base& t) override
     {
@@ -134,7 +134,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
     // Inherited from AbstractTool at this scope
       // std::string const getDbName() const;
       // virtual void printVersion() const;
-    // Inherited from AbstractImportTool at this scope
+    // Inherited from AbstractImportSpiritTool at this scope
       // fs::path    const getDataPath() const;
       // std::string const getDeviceId() const;
       // nmco::Uuid   const getToolRunId() const;

--- a/datastore/importers/nmdb-import-apk/nmdb-import-apk.cpp
+++ b/datastore/importers/nmdb-import-apk/nmdb-import-apk.cpp
@@ -24,7 +24,7 @@
 // Maintained by Sandia National Laboratories <Netmeld@sandia.gov>
 // =============================================================================
 
-#include <netmeld/datastore/tools/AbstractImportTool.hpp>
+#include <netmeld/datastore/tools/AbstractImportSpiritTool.hpp>
 #include "Parser.hpp"
 
 namespace nmdt = netmeld::datastore::tools;
@@ -33,7 +33,7 @@ namespace nmdt = netmeld::datastore::tools;
 // Import tool definition
 // =============================================================================
 template<typename P, typename R>
-class Tool : public nmdt::AbstractImportTool<P,R>
+class Tool : public nmdt::AbstractImportSpiritTool<P,R>
 {
   // ===========================================================================
   // Variables
@@ -48,7 +48,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
   private:
   protected:
   public:
-    Tool() : nmdt::AbstractImportTool<P,R>
+    Tool() : nmdt::AbstractImportSpiritTool<P,R>
       (
        "apk list -I -v",       // command line tool imports data from
        PROGRAM_NAME,           // program name (set in CMakeLists.txt)

--- a/datastore/importers/nmdb-import-aws-ec2-describe-instances/Parser.cpp
+++ b/datastore/importers/nmdb-import-aws-ec2-describe-instances/Parser.cpp
@@ -38,12 +38,8 @@ Parser::Parser()
 void
 Parser::fromJson(const json& _data)
 {
-  try {
-    for (const auto& reservation : _data.at("Reservations")) {
-      processInstances(reservation);
-    }
-  } catch (json::out_of_range& ex) {
-    LOG_ERROR << "Parse error " << ex.what() << std::endl;
+  for (const auto& reservation : _data.at("Reservations")) {
+    processInstances(reservation);
   }
 }
 

--- a/datastore/importers/nmdb-import-aws-ec2-describe-instances/nmdb-import-aws-ec2-describe-instances.cpp
+++ b/datastore/importers/nmdb-import-aws-ec2-describe-instances/nmdb-import-aws-ec2-describe-instances.cpp
@@ -26,7 +26,7 @@
 
 #include <nlohmann/json.hpp>
 
-#include <netmeld/datastore/tools/AbstractImportTool.hpp>
+#include <netmeld/datastore/tools/AbstractImportJsonTool.hpp>
 #include <netmeld/datastore/parsers/ParserHelper.hpp> // if parser not needed
 
 #include "Parser.hpp"
@@ -40,7 +40,7 @@ using json = nlohmann::json;
 // Import tool definition
 // =============================================================================
 template<typename P, typename R>
-class Tool : public nmdt::AbstractImportTool<P,R>
+class Tool : public nmdt::AbstractImportJsonTool<P,R>
 {
   // ===========================================================================
   // Variables
@@ -56,7 +56,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
   private: // Constructors should rarely appear at this scope
   protected: // Constructors intended for internal/subclass API
   public: // Constructors should generally be public
-    Tool() : nmdt::AbstractImportTool<P,R>
+    Tool() : nmdt::AbstractImportJsonTool<P,R>
       (
        "aws ec2 describe-instances",  // command line tool imports data from
        PROGRAM_NAME,           // program name (set in CMakeLists.txt)
@@ -69,7 +69,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
   // Methods
   // ===========================================================================
   private: // Methods part of internal API
-    // Overriden from AbstractImportTool
+    // Overriden from AbstractImportJsonTool
     void
     addToolOptions() override
     {
@@ -84,25 +84,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
       this->opts.removeOptionalOption("device-color");
     }
 
-    // Overriden from AbstractImportTool
-    void
-    parseData() override
-    {
-      std::ifstream f {this->getDataPath().string()};
-
-      this->executionStart = nmco::Time();
-      try {
-        Parser parser;
-        parser.fromJson(json::parse(f));
-        this->tResults = parser.getData();
-      } catch (json::parse_error& ex) {
-        LOG_ERROR << "Parse error at byte " << ex.byte
-                  << std::endl;
-      }
-      this->executionStop = nmco::Time();
-    }
-
-    // Overriden from AbstractImportTool
+    // Overriden from AbstractImportJsonTool
     void
     specificInserts(pqxx::transaction_base& t) override
     {
@@ -131,6 +113,6 @@ class Tool : public nmdt::AbstractImportTool<P,R>
 // Program entry point
 // =============================================================================
 int main(int argc, char** argv) {
-  Tool<nmdp::DummyParser, Result> tool; // if parser not needed
+  Tool<Parser, Result> tool; // if parser not needed
   return tool.start(argc, argv);
 }

--- a/datastore/importers/nmdb-import-aws-ec2-describe-instances/nmdb-import-aws-ec2-describe-instances.cpp
+++ b/datastore/importers/nmdb-import-aws-ec2-describe-instances/nmdb-import-aws-ec2-describe-instances.cpp
@@ -24,8 +24,6 @@
 // Maintained by Sandia National Laboratories <Netmeld@sandia.gov>
 // =============================================================================
 
-#include <nlohmann/json.hpp>
-
 #include <netmeld/datastore/tools/AbstractImportJsonTool.hpp>
 
 #include "Parser.hpp"

--- a/datastore/importers/nmdb-import-aws-ec2-describe-instances/nmdb-import-aws-ec2-describe-instances.cpp
+++ b/datastore/importers/nmdb-import-aws-ec2-describe-instances/nmdb-import-aws-ec2-describe-instances.cpp
@@ -27,7 +27,6 @@
 #include <nlohmann/json.hpp>
 
 #include <netmeld/datastore/tools/AbstractImportJsonTool.hpp>
-#include <netmeld/datastore/parsers/ParserHelper.hpp> // if parser not needed
 
 #include "Parser.hpp"
 
@@ -113,6 +112,6 @@ class Tool : public nmdt::AbstractImportJsonTool<P,R>
 // Program entry point
 // =============================================================================
 int main(int argc, char** argv) {
-  Tool<Parser, Result> tool; // if parser not needed
+  Tool<Parser, Result> tool;
   return tool.start(argc, argv);
 }

--- a/datastore/importers/nmdb-import-aws-ec2-describe-network-acls/nmdb-import-aws-ec2-describe-network-acls.cpp
+++ b/datastore/importers/nmdb-import-aws-ec2-describe-network-acls/nmdb-import-aws-ec2-describe-network-acls.cpp
@@ -26,7 +26,7 @@
 
 #include <nlohmann/json.hpp>
 
-#include <netmeld/datastore/tools/AbstractImportTool.hpp>
+#include <netmeld/datastore/tools/AbstractImportSpiritTool.hpp>
 #include <netmeld/datastore/parsers/ParserHelper.hpp> // if parser not needed
 
 #include "Parser.hpp"
@@ -40,7 +40,7 @@ using json = nlohmann::json;
 // Import tool definition
 // =============================================================================
 template<typename P, typename R>
-class Tool : public nmdt::AbstractImportTool<P,R>
+class Tool : public nmdt::AbstractImportSpiritTool<P,R>
 {
   // ===========================================================================
   // Variables
@@ -56,7 +56,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
   private: // Constructors should rarely appear at this scope
   protected: // Constructors intended for internal/subclass API
   public: // Constructors should generally be public
-    Tool() : nmdt::AbstractImportTool<P,R>
+    Tool() : nmdt::AbstractImportSpiritTool<P,R>
       (
        "aws ec2 describe-security-groups",  // command line tool imports data from
        PROGRAM_NAME,           // program name (set in CMakeLists.txt)
@@ -69,7 +69,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
   // Methods
   // ===========================================================================
   private: // Methods part of internal API
-    // Overriden from AbstractImportTool
+    // Overriden from AbstractImportSpiritTool
     void
     addToolOptions() override
     {
@@ -84,7 +84,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
       this->opts.removeOptionalOption("device-color");
     }
 
-    // Overriden from AbstractImportTool
+    // Overriden from AbstractImportSpiritTool
     void
     parseData() override
     {
@@ -102,7 +102,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
       this->executionStop = nmco::Time();
     }
 
-    // Overriden from AbstractImportTool
+    // Overriden from AbstractImportSpiritTool
     void
     specificInserts(pqxx::transaction_base& t) override
     {

--- a/datastore/importers/nmdb-import-aws-ec2-describe-network-acls/nmdb-import-aws-ec2-describe-network-acls.cpp
+++ b/datastore/importers/nmdb-import-aws-ec2-describe-network-acls/nmdb-import-aws-ec2-describe-network-acls.cpp
@@ -26,8 +26,7 @@
 
 #include <nlohmann/json.hpp>
 
-#include <netmeld/datastore/tools/AbstractImportSpiritTool.hpp>
-#include <netmeld/datastore/parsers/ParserHelper.hpp> // if parser not needed
+#include <netmeld/datastore/tools/AbstractImportJsonTool.hpp>
 
 #include "Parser.hpp"
 
@@ -40,7 +39,7 @@ using json = nlohmann::json;
 // Import tool definition
 // =============================================================================
 template<typename P, typename R>
-class Tool : public nmdt::AbstractImportSpiritTool<P,R>
+class Tool : public nmdt::AbstractImportJsonTool<P,R>
 {
   // ===========================================================================
   // Variables
@@ -56,7 +55,7 @@ class Tool : public nmdt::AbstractImportSpiritTool<P,R>
   private: // Constructors should rarely appear at this scope
   protected: // Constructors intended for internal/subclass API
   public: // Constructors should generally be public
-    Tool() : nmdt::AbstractImportSpiritTool<P,R>
+    Tool() : nmdt::AbstractImportJsonTool<P,R>
       (
        "aws ec2 describe-security-groups",  // command line tool imports data from
        PROGRAM_NAME,           // program name (set in CMakeLists.txt)
@@ -69,7 +68,7 @@ class Tool : public nmdt::AbstractImportSpiritTool<P,R>
   // Methods
   // ===========================================================================
   private: // Methods part of internal API
-    // Overriden from AbstractImportSpiritTool
+    // Overriden from AbstractImportJsonTool
     void
     addToolOptions() override
     {
@@ -84,25 +83,7 @@ class Tool : public nmdt::AbstractImportSpiritTool<P,R>
       this->opts.removeOptionalOption("device-color");
     }
 
-    // Overriden from AbstractImportSpiritTool
-    void
-    parseData() override
-    {
-      std::ifstream f {this->getDataPath().string()};
-
-      this->executionStart = nmco::Time();
-      try {
-        Parser parser;
-        parser.fromJson(json::parse(f));
-        this->tResults = parser.getData();
-      } catch (json::parse_error& ex) {
-        LOG_ERROR << "Parse error at byte " << ex.byte
-                  << std::endl;
-      }
-      this->executionStop = nmco::Time();
-    }
-
-    // Overriden from AbstractImportSpiritTool
+    // Overriden from AbstractImportJsonTool
     void
     specificInserts(pqxx::transaction_base& t) override
     {
@@ -131,6 +112,6 @@ class Tool : public nmdt::AbstractImportSpiritTool<P,R>
 // Program entry point
 // =============================================================================
 int main(int argc, char** argv) {
-  Tool<nmdp::DummyParser, Result> tool; // if parser not needed
+  Tool<Parser, Result> tool;
   return tool.start(argc, argv);
 }

--- a/datastore/importers/nmdb-import-aws-ec2-describe-network-acls/nmdb-import-aws-ec2-describe-network-acls.cpp
+++ b/datastore/importers/nmdb-import-aws-ec2-describe-network-acls/nmdb-import-aws-ec2-describe-network-acls.cpp
@@ -24,8 +24,6 @@
 // Maintained by Sandia National Laboratories <Netmeld@sandia.gov>
 // =============================================================================
 
-#include <nlohmann/json.hpp>
-
 #include <netmeld/datastore/tools/AbstractImportJsonTool.hpp>
 
 #include "Parser.hpp"

--- a/datastore/importers/nmdb-import-aws-ec2-describe-network-interfaces/nmdb-import-aws-ec2-describe-network-interfaces.cpp
+++ b/datastore/importers/nmdb-import-aws-ec2-describe-network-interfaces/nmdb-import-aws-ec2-describe-network-interfaces.cpp
@@ -26,7 +26,7 @@
 
 #include <nlohmann/json.hpp>
 
-#include <netmeld/datastore/tools/AbstractImportTool.hpp>
+#include <netmeld/datastore/tools/AbstractImportSpiritTool.hpp>
 #include <netmeld/datastore/parsers/ParserHelper.hpp> // if parser not needed
 
 #include "Parser.hpp"
@@ -40,7 +40,7 @@ using json = nlohmann::json;
 // Import tool definition
 // =============================================================================
 template<typename P, typename R>
-class Tool : public nmdt::AbstractImportTool<P,R>
+class Tool : public nmdt::AbstractImportSpiritTool<P,R>
 {
   // ===========================================================================
   // Variables
@@ -56,7 +56,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
   private: // Constructors should rarely appear at this scope
   protected: // Constructors intended for internal/subclass API
   public: // Constructors should generally be public
-    Tool() : nmdt::AbstractImportTool<P,R>
+    Tool() : nmdt::AbstractImportSpiritTool<P,R>
       (
                               // command line tool imports data from
        "aws ec2 describe-network-interfaces",
@@ -70,7 +70,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
   // Methods
   // ===========================================================================
   private: // Methods part of internal API
-    // Overriden from AbstractImportTool
+    // Overriden from AbstractImportSpiritTool
     void
     addToolOptions() override
     {
@@ -85,7 +85,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
       this->opts.removeOptionalOption("device-color");
     }
 
-    // Overriden from AbstractImportTool
+    // Overriden from AbstractImportSpiritTool
     void
     parseData() override
     {
@@ -100,7 +100,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
       this->executionStop = nmco::Time();
     }
 
-    // Overriden from AbstractImportTool
+    // Overriden from AbstractImportSpiritTool
     void
     specificInserts(pqxx::transaction_base& t) override
     {

--- a/datastore/importers/nmdb-import-aws-ec2-describe-network-interfaces/nmdb-import-aws-ec2-describe-network-interfaces.cpp
+++ b/datastore/importers/nmdb-import-aws-ec2-describe-network-interfaces/nmdb-import-aws-ec2-describe-network-interfaces.cpp
@@ -24,8 +24,6 @@
 // Maintained by Sandia National Laboratories <Netmeld@sandia.gov>
 // =============================================================================
 
-#include <nlohmann/json.hpp>
-
 #include <netmeld/datastore/tools/AbstractImportJsonTool.hpp>
 
 #include "Parser.hpp"

--- a/datastore/importers/nmdb-import-aws-ec2-describe-network-interfaces/nmdb-import-aws-ec2-describe-network-interfaces.cpp
+++ b/datastore/importers/nmdb-import-aws-ec2-describe-network-interfaces/nmdb-import-aws-ec2-describe-network-interfaces.cpp
@@ -26,8 +26,7 @@
 
 #include <nlohmann/json.hpp>
 
-#include <netmeld/datastore/tools/AbstractImportSpiritTool.hpp>
-#include <netmeld/datastore/parsers/ParserHelper.hpp> // if parser not needed
+#include <netmeld/datastore/tools/AbstractImportJsonTool.hpp>
 
 #include "Parser.hpp"
 
@@ -40,7 +39,7 @@ using json = nlohmann::json;
 // Import tool definition
 // =============================================================================
 template<typename P, typename R>
-class Tool : public nmdt::AbstractImportSpiritTool<P,R>
+class Tool : public nmdt::AbstractImportJsonTool<P,R>
 {
   // ===========================================================================
   // Variables
@@ -56,7 +55,7 @@ class Tool : public nmdt::AbstractImportSpiritTool<P,R>
   private: // Constructors should rarely appear at this scope
   protected: // Constructors intended for internal/subclass API
   public: // Constructors should generally be public
-    Tool() : nmdt::AbstractImportSpiritTool<P,R>
+    Tool() : nmdt::AbstractImportJsonTool<P,R>
       (
                               // command line tool imports data from
        "aws ec2 describe-network-interfaces",
@@ -70,7 +69,7 @@ class Tool : public nmdt::AbstractImportSpiritTool<P,R>
   // Methods
   // ===========================================================================
   private: // Methods part of internal API
-    // Overriden from AbstractImportSpiritTool
+    // Overriden from AbstractImportJsonTool
     void
     addToolOptions() override
     {
@@ -85,22 +84,7 @@ class Tool : public nmdt::AbstractImportSpiritTool<P,R>
       this->opts.removeOptionalOption("device-color");
     }
 
-    // Overriden from AbstractImportSpiritTool
-    void
-    parseData() override
-    {
-      std::ifstream f {this->getDataPath().string()};
-
-      this->executionStart = nmco::Time();
-
-      Parser parser;
-      parser.fromJson(json::parse(f));
-      this->tResults = parser.getData();
-
-      this->executionStop = nmco::Time();
-    }
-
-    // Overriden from AbstractImportSpiritTool
+    // Overriden from AbstractImportJsonTool
     void
     specificInserts(pqxx::transaction_base& t) override
     {
@@ -129,6 +113,6 @@ class Tool : public nmdt::AbstractImportSpiritTool<P,R>
 // Program entry point
 // =============================================================================
 int main(int argc, char** argv) {
-  Tool<nmdp::DummyParser, Result> tool; // if parser not needed
+  Tool<Parser, Result> tool;
   return tool.start(argc, argv);
 }

--- a/datastore/importers/nmdb-import-aws-ec2-describe-route-tables/nmdb-import-aws-ec2-describe-route-tables.cpp
+++ b/datastore/importers/nmdb-import-aws-ec2-describe-route-tables/nmdb-import-aws-ec2-describe-route-tables.cpp
@@ -26,7 +26,7 @@
 
 #include <nlohmann/json.hpp>
 
-#include <netmeld/datastore/tools/AbstractImportTool.hpp>
+#include <netmeld/datastore/tools/AbstractImportSpiritTool.hpp>
 #include <netmeld/datastore/parsers/ParserHelper.hpp> // if parser not needed
 
 #include "Parser.hpp"
@@ -40,7 +40,7 @@ using json = nlohmann::json;
 // Import tool definition
 // =============================================================================
 template<typename P, typename R>
-class Tool : public nmdt::AbstractImportTool<P,R>
+class Tool : public nmdt::AbstractImportSpiritTool<P,R>
 {
   // ===========================================================================
   // Variables
@@ -56,7 +56,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
   private: // Constructors should rarely appear at this scope
   protected: // Constructors intended for internal/subclass API
   public: // Constructors should generally be public
-    Tool() : nmdt::AbstractImportTool<P,R>
+    Tool() : nmdt::AbstractImportSpiritTool<P,R>
       (
        "aws ec2 describe-route-tables",  // command line tool imports data from
        PROGRAM_NAME,           // program name (set in CMakeLists.txt)
@@ -69,7 +69,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
   // Methods
   // ===========================================================================
   private: // Methods part of internal API
-    // Overriden from AbstractImportTool
+    // Overriden from AbstractImportSpiritTool
     void
     addToolOptions() override
     {
@@ -84,7 +84,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
       this->opts.removeOptionalOption("device-color");
     }
 
-    // Overriden from AbstractImportTool
+    // Overriden from AbstractImportSpiritTool
     void
     parseData() override
     {
@@ -102,7 +102,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
       this->executionStop = nmco::Time();
     }
 
-    // Overriden from AbstractImportTool
+    // Overriden from AbstractImportSpiritTool
     void
     specificInserts(pqxx::transaction_base& t) override
     {

--- a/datastore/importers/nmdb-import-aws-ec2-describe-route-tables/nmdb-import-aws-ec2-describe-route-tables.cpp
+++ b/datastore/importers/nmdb-import-aws-ec2-describe-route-tables/nmdb-import-aws-ec2-describe-route-tables.cpp
@@ -24,8 +24,6 @@
 // Maintained by Sandia National Laboratories <Netmeld@sandia.gov>
 // =============================================================================
 
-#include <nlohmann/json.hpp>
-
 #include <netmeld/datastore/tools/AbstractImportJsonTool.hpp>
 
 #include "Parser.hpp"

--- a/datastore/importers/nmdb-import-aws-ec2-describe-route-tables/nmdb-import-aws-ec2-describe-route-tables.cpp
+++ b/datastore/importers/nmdb-import-aws-ec2-describe-route-tables/nmdb-import-aws-ec2-describe-route-tables.cpp
@@ -26,8 +26,7 @@
 
 #include <nlohmann/json.hpp>
 
-#include <netmeld/datastore/tools/AbstractImportSpiritTool.hpp>
-#include <netmeld/datastore/parsers/ParserHelper.hpp> // if parser not needed
+#include <netmeld/datastore/tools/AbstractImportJsonTool.hpp>
 
 #include "Parser.hpp"
 
@@ -40,7 +39,7 @@ using json = nlohmann::json;
 // Import tool definition
 // =============================================================================
 template<typename P, typename R>
-class Tool : public nmdt::AbstractImportSpiritTool<P,R>
+class Tool : public nmdt::AbstractImportJsonTool<P,R>
 {
   // ===========================================================================
   // Variables
@@ -56,7 +55,7 @@ class Tool : public nmdt::AbstractImportSpiritTool<P,R>
   private: // Constructors should rarely appear at this scope
   protected: // Constructors intended for internal/subclass API
   public: // Constructors should generally be public
-    Tool() : nmdt::AbstractImportSpiritTool<P,R>
+    Tool() : nmdt::AbstractImportJsonTool<P,R>
       (
        "aws ec2 describe-route-tables",  // command line tool imports data from
        PROGRAM_NAME,           // program name (set in CMakeLists.txt)
@@ -69,7 +68,7 @@ class Tool : public nmdt::AbstractImportSpiritTool<P,R>
   // Methods
   // ===========================================================================
   private: // Methods part of internal API
-    // Overriden from AbstractImportSpiritTool
+    // Overriden from AbstractImportJsonTool
     void
     addToolOptions() override
     {
@@ -84,25 +83,7 @@ class Tool : public nmdt::AbstractImportSpiritTool<P,R>
       this->opts.removeOptionalOption("device-color");
     }
 
-    // Overriden from AbstractImportSpiritTool
-    void
-    parseData() override
-    {
-      std::ifstream f {this->getDataPath().string()};
-
-      this->executionStart = nmco::Time();
-      try {
-        Parser parser;
-        parser.fromJson(json::parse(f));
-        this->tResults = parser.getData();
-      } catch (json::parse_error& ex) {
-        LOG_ERROR << "Parse error at byte " << ex.byte
-                  << std::endl;
-      }
-      this->executionStop = nmco::Time();
-    }
-
-    // Overriden from AbstractImportSpiritTool
+    // Overriden from AbstractImportJsonTool
     void
     specificInserts(pqxx::transaction_base& t) override
     {
@@ -131,6 +112,6 @@ class Tool : public nmdt::AbstractImportSpiritTool<P,R>
 // Program entry point
 // =============================================================================
 int main(int argc, char** argv) {
-  Tool<nmdp::DummyParser, Result> tool; // if parser not needed
+  Tool<Parser, Result> tool;
   return tool.start(argc, argv);
 }

--- a/datastore/importers/nmdb-import-aws-ec2-describe-security-groups/nmdb-import-aws-ec2-describe-security-groups.cpp
+++ b/datastore/importers/nmdb-import-aws-ec2-describe-security-groups/nmdb-import-aws-ec2-describe-security-groups.cpp
@@ -26,7 +26,7 @@
 
 #include <nlohmann/json.hpp>
 
-#include <netmeld/datastore/tools/AbstractImportTool.hpp>
+#include <netmeld/datastore/tools/AbstractImportSpiritTool.hpp>
 #include <netmeld/datastore/parsers/ParserHelper.hpp> // if parser not needed
 
 #include "Parser.hpp"
@@ -40,7 +40,7 @@ using json = nlohmann::json;
 // Import tool definition
 // =============================================================================
 template<typename P, typename R>
-class Tool : public nmdt::AbstractImportTool<P,R>
+class Tool : public nmdt::AbstractImportSpiritTool<P,R>
 {
   // ===========================================================================
   // Variables
@@ -56,7 +56,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
   private: // Constructors should rarely appear at this scope
   protected: // Constructors intended for internal/subclass API
   public: // Constructors should generally be public
-    Tool() : nmdt::AbstractImportTool<P,R>
+    Tool() : nmdt::AbstractImportSpiritTool<P,R>
       (
        "aws ec2 describe-security-groups",  // command line tool imports data from
        PROGRAM_NAME,           // program name (set in CMakeLists.txt)
@@ -69,7 +69,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
   // Methods
   // ===========================================================================
   private: // Methods part of internal API
-    // Overriden from AbstractImportTool
+    // Overriden from AbstractImportSpiritTool
     void
     addToolOptions() override
     {
@@ -84,7 +84,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
       this->opts.removeOptionalOption("device-color");
     }
 
-    // Overriden from AbstractImportTool
+    // Overriden from AbstractImportSpiritTool
     void
     parseData() override
     {
@@ -102,7 +102,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
       this->executionStop = nmco::Time();
     }
 
-    // Overriden from AbstractImportTool
+    // Overriden from AbstractImportSpiritTool
     void
     specificInserts(pqxx::transaction_base& t) override
     {

--- a/datastore/importers/nmdb-import-aws-ec2-describe-security-groups/nmdb-import-aws-ec2-describe-security-groups.cpp
+++ b/datastore/importers/nmdb-import-aws-ec2-describe-security-groups/nmdb-import-aws-ec2-describe-security-groups.cpp
@@ -26,8 +26,7 @@
 
 #include <nlohmann/json.hpp>
 
-#include <netmeld/datastore/tools/AbstractImportSpiritTool.hpp>
-#include <netmeld/datastore/parsers/ParserHelper.hpp> // if parser not needed
+#include <netmeld/datastore/tools/AbstractImportJsonTool.hpp>
 
 #include "Parser.hpp"
 
@@ -40,7 +39,7 @@ using json = nlohmann::json;
 // Import tool definition
 // =============================================================================
 template<typename P, typename R>
-class Tool : public nmdt::AbstractImportSpiritTool<P,R>
+class Tool : public nmdt::AbstractImportJsonTool<P,R>
 {
   // ===========================================================================
   // Variables
@@ -56,7 +55,7 @@ class Tool : public nmdt::AbstractImportSpiritTool<P,R>
   private: // Constructors should rarely appear at this scope
   protected: // Constructors intended for internal/subclass API
   public: // Constructors should generally be public
-    Tool() : nmdt::AbstractImportSpiritTool<P,R>
+    Tool() : nmdt::AbstractImportJsonTool<P,R>
       (
        "aws ec2 describe-security-groups",  // command line tool imports data from
        PROGRAM_NAME,           // program name (set in CMakeLists.txt)
@@ -69,7 +68,7 @@ class Tool : public nmdt::AbstractImportSpiritTool<P,R>
   // Methods
   // ===========================================================================
   private: // Methods part of internal API
-    // Overriden from AbstractImportSpiritTool
+    // Overriden from AbstractImportJsonTool
     void
     addToolOptions() override
     {
@@ -84,25 +83,7 @@ class Tool : public nmdt::AbstractImportSpiritTool<P,R>
       this->opts.removeOptionalOption("device-color");
     }
 
-    // Overriden from AbstractImportSpiritTool
-    void
-    parseData() override
-    {
-      std::ifstream f {this->getDataPath().string()};
-
-      this->executionStart = nmco::Time();
-      try {
-        Parser parser;
-        parser.fromJson(json::parse(f));
-        this->tResults = parser.getData();
-      } catch (json::parse_error& ex) {
-        LOG_ERROR << "Parse error at byte " << ex.byte
-                  << std::endl;
-      }
-      this->executionStop = nmco::Time();
-    }
-
-    // Overriden from AbstractImportSpiritTool
+    // Overriden from AbstractImportJsonTool
     void
     specificInserts(pqxx::transaction_base& t) override
     {
@@ -131,6 +112,6 @@ class Tool : public nmdt::AbstractImportSpiritTool<P,R>
 // Program entry point
 // =============================================================================
 int main(int argc, char** argv) {
-  Tool<nmdp::DummyParser, Result> tool; // if parser not needed
+  Tool<Parser, Result> tool;
   return tool.start(argc, argv);
 }

--- a/datastore/importers/nmdb-import-aws-ec2-describe-security-groups/nmdb-import-aws-ec2-describe-security-groups.cpp
+++ b/datastore/importers/nmdb-import-aws-ec2-describe-security-groups/nmdb-import-aws-ec2-describe-security-groups.cpp
@@ -24,8 +24,6 @@
 // Maintained by Sandia National Laboratories <Netmeld@sandia.gov>
 // =============================================================================
 
-#include <nlohmann/json.hpp>
-
 #include <netmeld/datastore/tools/AbstractImportJsonTool.hpp>
 
 #include "Parser.hpp"

--- a/datastore/importers/nmdb-import-aws-ec2-describe-subnets/nmdb-import-aws-ec2-describe-subnets.cpp
+++ b/datastore/importers/nmdb-import-aws-ec2-describe-subnets/nmdb-import-aws-ec2-describe-subnets.cpp
@@ -24,8 +24,6 @@
 // Maintained by Sandia National Laboratories <Netmeld@sandia.gov>
 // =============================================================================
 
-#include <nlohmann/json.hpp>
-
 #include <netmeld/datastore/tools/AbstractImportJsonTool.hpp>
 
 #include "Parser.hpp"

--- a/datastore/importers/nmdb-import-aws-ec2-describe-subnets/nmdb-import-aws-ec2-describe-subnets.cpp
+++ b/datastore/importers/nmdb-import-aws-ec2-describe-subnets/nmdb-import-aws-ec2-describe-subnets.cpp
@@ -26,8 +26,7 @@
 
 #include <nlohmann/json.hpp>
 
-#include <netmeld/datastore/tools/AbstractImportSpiritTool.hpp>
-#include <netmeld/datastore/parsers/ParserHelper.hpp> // if parser not needed
+#include <netmeld/datastore/tools/AbstractImportJsonTool.hpp>
 
 #include "Parser.hpp"
 
@@ -40,7 +39,7 @@ using json = nlohmann::json;
 // Import tool definition
 // =============================================================================
 template<typename P, typename R>
-class Tool : public nmdt::AbstractImportSpiritTool<P,R>
+class Tool : public nmdt::AbstractImportJsonTool<P,R>
 {
   // ===========================================================================
   // Variables
@@ -56,7 +55,7 @@ class Tool : public nmdt::AbstractImportSpiritTool<P,R>
   private: // Constructors should rarely appear at this scope
   protected: // Constructors intended for internal/subclass API
   public: // Constructors should generally be public
-    Tool() : nmdt::AbstractImportSpiritTool<P,R>
+    Tool() : nmdt::AbstractImportJsonTool<P,R>
       (
        "aws ec2 describe-subnets",  // command line tool imports data from
        PROGRAM_NAME,           // program name (set in CMakeLists.txt)
@@ -69,7 +68,7 @@ class Tool : public nmdt::AbstractImportSpiritTool<P,R>
   // Methods
   // ===========================================================================
   private: // Methods part of internal API
-    // Overriden from AbstractImportSpiritTool
+    // Overriden from AbstractImportJsonTool
     void
     addToolOptions() override
     {
@@ -84,25 +83,7 @@ class Tool : public nmdt::AbstractImportSpiritTool<P,R>
       this->opts.removeOptionalOption("device-color");
     }
 
-    // Overriden from AbstractImportSpiritTool
-    void
-    parseData() override
-    {
-      std::ifstream f {this->getDataPath().string()};
-
-      this->executionStart = nmco::Time();
-      try {
-        Parser parser;
-        parser.fromJson(json::parse(f));
-        this->tResults = parser.getData();
-      } catch (json::parse_error& ex) {
-        LOG_ERROR << "Parse error at byte " << ex.byte
-                  << std::endl;
-      }
-      this->executionStop = nmco::Time();
-    }
-
-    // Overriden from AbstractImportSpiritTool
+    // Overriden from AbstractImportJsonTool
     void
     specificInserts(pqxx::transaction_base& t) override
     {
@@ -131,6 +112,6 @@ class Tool : public nmdt::AbstractImportSpiritTool<P,R>
 // Program entry point
 // =============================================================================
 int main(int argc, char** argv) {
-  Tool<nmdp::DummyParser, Result> tool; // if parser not needed
+  Tool<Parser, Result> tool;
   return tool.start(argc, argv);
 }

--- a/datastore/importers/nmdb-import-aws-ec2-describe-subnets/nmdb-import-aws-ec2-describe-subnets.cpp
+++ b/datastore/importers/nmdb-import-aws-ec2-describe-subnets/nmdb-import-aws-ec2-describe-subnets.cpp
@@ -26,7 +26,7 @@
 
 #include <nlohmann/json.hpp>
 
-#include <netmeld/datastore/tools/AbstractImportTool.hpp>
+#include <netmeld/datastore/tools/AbstractImportSpiritTool.hpp>
 #include <netmeld/datastore/parsers/ParserHelper.hpp> // if parser not needed
 
 #include "Parser.hpp"
@@ -40,7 +40,7 @@ using json = nlohmann::json;
 // Import tool definition
 // =============================================================================
 template<typename P, typename R>
-class Tool : public nmdt::AbstractImportTool<P,R>
+class Tool : public nmdt::AbstractImportSpiritTool<P,R>
 {
   // ===========================================================================
   // Variables
@@ -56,7 +56,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
   private: // Constructors should rarely appear at this scope
   protected: // Constructors intended for internal/subclass API
   public: // Constructors should generally be public
-    Tool() : nmdt::AbstractImportTool<P,R>
+    Tool() : nmdt::AbstractImportSpiritTool<P,R>
       (
        "aws ec2 describe-subnets",  // command line tool imports data from
        PROGRAM_NAME,           // program name (set in CMakeLists.txt)
@@ -69,7 +69,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
   // Methods
   // ===========================================================================
   private: // Methods part of internal API
-    // Overriden from AbstractImportTool
+    // Overriden from AbstractImportSpiritTool
     void
     addToolOptions() override
     {
@@ -84,7 +84,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
       this->opts.removeOptionalOption("device-color");
     }
 
-    // Overriden from AbstractImportTool
+    // Overriden from AbstractImportSpiritTool
     void
     parseData() override
     {
@@ -102,7 +102,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
       this->executionStop = nmco::Time();
     }
 
-    // Overriden from AbstractImportTool
+    // Overriden from AbstractImportSpiritTool
     void
     specificInserts(pqxx::transaction_base& t) override
     {

--- a/datastore/importers/nmdb-import-aws-ec2-describe-transit-gateway-attachments/nmdb-import-aws-ec2-describe-transit-gateway-attachments.cpp
+++ b/datastore/importers/nmdb-import-aws-ec2-describe-transit-gateway-attachments/nmdb-import-aws-ec2-describe-transit-gateway-attachments.cpp
@@ -24,8 +24,6 @@
 // Maintained by Sandia National Laboratories <Netmeld@sandia.gov>
 // =============================================================================
 
-#include <nlohmann/json.hpp>
-
 #include <netmeld/datastore/tools/AbstractImportJsonTool.hpp>
 
 #include "Parser.hpp"

--- a/datastore/importers/nmdb-import-aws-ec2-describe-transit-gateway-attachments/nmdb-import-aws-ec2-describe-transit-gateway-attachments.cpp
+++ b/datastore/importers/nmdb-import-aws-ec2-describe-transit-gateway-attachments/nmdb-import-aws-ec2-describe-transit-gateway-attachments.cpp
@@ -26,7 +26,7 @@
 
 #include <nlohmann/json.hpp>
 
-#include <netmeld/datastore/tools/AbstractImportTool.hpp>
+#include <netmeld/datastore/tools/AbstractImportSpiritTool.hpp>
 #include <netmeld/datastore/parsers/ParserHelper.hpp> // if parser not needed
 
 #include "Parser.hpp"
@@ -40,7 +40,7 @@ using json = nlohmann::json;
 // Import tool definition
 // =============================================================================
 template<typename P, typename R>
-class Tool : public nmdt::AbstractImportTool<P,R>
+class Tool : public nmdt::AbstractImportSpiritTool<P,R>
 {
   // ===========================================================================
   // Variables
@@ -56,7 +56,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
   private: // Constructors should rarely appear at this scope
   protected: // Constructors intended for internal/subclass API
   public: // Constructors should generally be public
-    Tool() : nmdt::AbstractImportTool<P,R>
+    Tool() : nmdt::AbstractImportSpiritTool<P,R>
       (
                               // command line tool imports data from
        "aws ec2 describe-transit-gateway-attachments",
@@ -70,7 +70,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
   // Methods
   // ===========================================================================
   private: // Methods part of internal API
-    // Overriden from AbstractImportTool
+    // Overriden from AbstractImportSpiritTool
     void
     addToolOptions() override
     {
@@ -85,7 +85,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
       this->opts.removeOptionalOption("device-color");
     }
 
-    // Overriden from AbstractImportTool
+    // Overriden from AbstractImportSpiritTool
     void
     parseData() override
     {
@@ -100,7 +100,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
       this->executionStop = nmco::Time();
     }
 
-    // Overriden from AbstractImportTool
+    // Overriden from AbstractImportSpiritTool
     void
     specificInserts(pqxx::transaction_base& t) override
     {

--- a/datastore/importers/nmdb-import-aws-ec2-describe-transit-gateway-attachments/nmdb-import-aws-ec2-describe-transit-gateway-attachments.cpp
+++ b/datastore/importers/nmdb-import-aws-ec2-describe-transit-gateway-attachments/nmdb-import-aws-ec2-describe-transit-gateway-attachments.cpp
@@ -26,8 +26,7 @@
 
 #include <nlohmann/json.hpp>
 
-#include <netmeld/datastore/tools/AbstractImportSpiritTool.hpp>
-#include <netmeld/datastore/parsers/ParserHelper.hpp> // if parser not needed
+#include <netmeld/datastore/tools/AbstractImportJsonTool.hpp>
 
 #include "Parser.hpp"
 
@@ -40,7 +39,7 @@ using json = nlohmann::json;
 // Import tool definition
 // =============================================================================
 template<typename P, typename R>
-class Tool : public nmdt::AbstractImportSpiritTool<P,R>
+class Tool : public nmdt::AbstractImportJsonTool<P,R>
 {
   // ===========================================================================
   // Variables
@@ -56,7 +55,7 @@ class Tool : public nmdt::AbstractImportSpiritTool<P,R>
   private: // Constructors should rarely appear at this scope
   protected: // Constructors intended for internal/subclass API
   public: // Constructors should generally be public
-    Tool() : nmdt::AbstractImportSpiritTool<P,R>
+    Tool() : nmdt::AbstractImportJsonTool<P,R>
       (
                               // command line tool imports data from
        "aws ec2 describe-transit-gateway-attachments",
@@ -70,7 +69,7 @@ class Tool : public nmdt::AbstractImportSpiritTool<P,R>
   // Methods
   // ===========================================================================
   private: // Methods part of internal API
-    // Overriden from AbstractImportSpiritTool
+    // Overriden from AbstractImportJsonTool
     void
     addToolOptions() override
     {
@@ -85,22 +84,7 @@ class Tool : public nmdt::AbstractImportSpiritTool<P,R>
       this->opts.removeOptionalOption("device-color");
     }
 
-    // Overriden from AbstractImportSpiritTool
-    void
-    parseData() override
-    {
-      std::ifstream f {this->getDataPath().string()};
-
-      this->executionStart = nmco::Time();
-
-      Parser parser;
-      parser.fromJson(json::parse(f));
-      this->tResults = parser.getData();
-
-      this->executionStop = nmco::Time();
-    }
-
-    // Overriden from AbstractImportSpiritTool
+    // Overriden from AbstractImportJsonTool
     void
     specificInserts(pqxx::transaction_base& t) override
     {
@@ -129,6 +113,6 @@ class Tool : public nmdt::AbstractImportSpiritTool<P,R>
 // Program entry point
 // =============================================================================
 int main(int argc, char** argv) {
-  Tool<nmdp::DummyParser, Result> tool; // if parser not needed
+  Tool<Parser, Result> tool;
   return tool.start(argc, argv);
 }

--- a/datastore/importers/nmdb-import-aws-ec2-describe-vpc-peering-connections/nmdb-import-aws-ec2-describe-vpc-peering-connections.cpp
+++ b/datastore/importers/nmdb-import-aws-ec2-describe-vpc-peering-connections/nmdb-import-aws-ec2-describe-vpc-peering-connections.cpp
@@ -26,7 +26,7 @@
 
 #include <nlohmann/json.hpp>
 
-#include <netmeld/datastore/tools/AbstractImportTool.hpp>
+#include <netmeld/datastore/tools/AbstractImportSpiritTool.hpp>
 #include <netmeld/datastore/parsers/ParserHelper.hpp> // if parser not needed
 
 #include "Parser.hpp"
@@ -40,7 +40,7 @@ using json = nlohmann::json;
 // Import tool definition
 // =============================================================================
 template<typename P, typename R>
-class Tool : public nmdt::AbstractImportTool<P,R>
+class Tool : public nmdt::AbstractImportSpiritTool<P,R>
 {
   // ===========================================================================
   // Variables
@@ -56,7 +56,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
   private: // Constructors should rarely appear at this scope
   protected: // Constructors intended for internal/subclass API
   public: // Constructors should generally be public
-    Tool() : nmdt::AbstractImportTool<P,R>
+    Tool() : nmdt::AbstractImportSpiritTool<P,R>
       (
                               // command line tool imports data from
        "aws ec2 describe-vpc-peering-connections",
@@ -70,7 +70,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
   // Methods
   // ===========================================================================
   private: // Methods part of internal API
-    // Overriden from AbstractImportTool
+    // Overriden from AbstractImportSpiritTool
     void
     addToolOptions() override
     {
@@ -85,7 +85,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
       this->opts.removeOptionalOption("device-color");
     }
 
-    // Overriden from AbstractImportTool
+    // Overriden from AbstractImportSpiritTool
     void
     parseData() override
     {
@@ -100,7 +100,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
       this->executionStop = nmco::Time();
     }
 
-    // Overriden from AbstractImportTool
+    // Overriden from AbstractImportSpiritTool
     void
     specificInserts(pqxx::transaction_base& t) override
     {

--- a/datastore/importers/nmdb-import-aws-ec2-describe-vpc-peering-connections/nmdb-import-aws-ec2-describe-vpc-peering-connections.cpp
+++ b/datastore/importers/nmdb-import-aws-ec2-describe-vpc-peering-connections/nmdb-import-aws-ec2-describe-vpc-peering-connections.cpp
@@ -24,8 +24,6 @@
 // Maintained by Sandia National Laboratories <Netmeld@sandia.gov>
 // =============================================================================
 
-#include <nlohmann/json.hpp>
-
 #include <netmeld/datastore/tools/AbstractImportJsonTool.hpp>
 
 #include "Parser.hpp"

--- a/datastore/importers/nmdb-import-aws-ec2-describe-vpc-peering-connections/nmdb-import-aws-ec2-describe-vpc-peering-connections.cpp
+++ b/datastore/importers/nmdb-import-aws-ec2-describe-vpc-peering-connections/nmdb-import-aws-ec2-describe-vpc-peering-connections.cpp
@@ -26,8 +26,7 @@
 
 #include <nlohmann/json.hpp>
 
-#include <netmeld/datastore/tools/AbstractImportSpiritTool.hpp>
-#include <netmeld/datastore/parsers/ParserHelper.hpp> // if parser not needed
+#include <netmeld/datastore/tools/AbstractImportJsonTool.hpp>
 
 #include "Parser.hpp"
 
@@ -40,7 +39,7 @@ using json = nlohmann::json;
 // Import tool definition
 // =============================================================================
 template<typename P, typename R>
-class Tool : public nmdt::AbstractImportSpiritTool<P,R>
+class Tool : public nmdt::AbstractImportJsonTool<P,R>
 {
   // ===========================================================================
   // Variables
@@ -56,7 +55,7 @@ class Tool : public nmdt::AbstractImportSpiritTool<P,R>
   private: // Constructors should rarely appear at this scope
   protected: // Constructors intended for internal/subclass API
   public: // Constructors should generally be public
-    Tool() : nmdt::AbstractImportSpiritTool<P,R>
+    Tool() : nmdt::AbstractImportJsonTool<P,R>
       (
                               // command line tool imports data from
        "aws ec2 describe-vpc-peering-connections",
@@ -70,7 +69,7 @@ class Tool : public nmdt::AbstractImportSpiritTool<P,R>
   // Methods
   // ===========================================================================
   private: // Methods part of internal API
-    // Overriden from AbstractImportSpiritTool
+    // Overriden from AbstractImportJsonTool
     void
     addToolOptions() override
     {
@@ -85,22 +84,7 @@ class Tool : public nmdt::AbstractImportSpiritTool<P,R>
       this->opts.removeOptionalOption("device-color");
     }
 
-    // Overriden from AbstractImportSpiritTool
-    void
-    parseData() override
-    {
-      std::ifstream f {this->getDataPath().string()};
-
-      this->executionStart = nmco::Time();
-
-      Parser parser;
-      parser.fromJson(json::parse(f));
-      this->tResults = parser.getData();
-
-      this->executionStop = nmco::Time();
-    }
-
-    // Overriden from AbstractImportSpiritTool
+    // Overriden from AbstractImportJsonTool
     void
     specificInserts(pqxx::transaction_base& t) override
     {
@@ -129,6 +113,6 @@ class Tool : public nmdt::AbstractImportSpiritTool<P,R>
 // Program entry point
 // =============================================================================
 int main(int argc, char** argv) {
-  Tool<nmdp::DummyParser, Result> tool; // if parser not needed
+  Tool<Parser, Result> tool;
   return tool.start(argc, argv);
 }

--- a/datastore/importers/nmdb-import-aws-ec2-describe-vpcs/nmdb-import-aws-ec2-describe-vpcs.cpp
+++ b/datastore/importers/nmdb-import-aws-ec2-describe-vpcs/nmdb-import-aws-ec2-describe-vpcs.cpp
@@ -26,7 +26,7 @@
 
 #include <nlohmann/json.hpp>
 
-#include <netmeld/datastore/tools/AbstractImportTool.hpp>
+#include <netmeld/datastore/tools/AbstractImportSpiritTool.hpp>
 #include <netmeld/datastore/parsers/ParserHelper.hpp> // if parser not needed
 
 #include "Parser.hpp"
@@ -40,7 +40,7 @@ using json = nlohmann::json;
 // Import tool definition
 // =============================================================================
 template<typename P, typename R>
-class Tool : public nmdt::AbstractImportTool<P,R>
+class Tool : public nmdt::AbstractImportSpiritTool<P,R>
 {
   // ===========================================================================
   // Variables
@@ -56,7 +56,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
   private: // Constructors should rarely appear at this scope
   protected: // Constructors intended for internal/subclass API
   public: // Constructors should generally be public
-    Tool() : nmdt::AbstractImportTool<P,R>
+    Tool() : nmdt::AbstractImportSpiritTool<P,R>
       (
        "aws ec2 describe-vpcs",  // command line tool imports data from
        PROGRAM_NAME,           // program name (set in CMakeLists.txt)
@@ -69,7 +69,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
   // Methods
   // ===========================================================================
   private: // Methods part of internal API
-    // Overriden from AbstractImportTool
+    // Overriden from AbstractImportSpiritTool
     void
     addToolOptions() override
     {
@@ -84,7 +84,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
       this->opts.removeOptionalOption("device-color");
     }
 
-    // Overriden from AbstractImportTool
+    // Overriden from AbstractImportSpiritTool
     void
     parseData() override
     {
@@ -102,7 +102,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
       this->executionStop = nmco::Time();
     }
 
-    // Overriden from AbstractImportTool
+    // Overriden from AbstractImportSpiritTool
     void
     specificInserts(pqxx::transaction_base& t) override
     {

--- a/datastore/importers/nmdb-import-aws-ec2-describe-vpcs/nmdb-import-aws-ec2-describe-vpcs.cpp
+++ b/datastore/importers/nmdb-import-aws-ec2-describe-vpcs/nmdb-import-aws-ec2-describe-vpcs.cpp
@@ -26,8 +26,7 @@
 
 #include <nlohmann/json.hpp>
 
-#include <netmeld/datastore/tools/AbstractImportSpiritTool.hpp>
-#include <netmeld/datastore/parsers/ParserHelper.hpp> // if parser not needed
+#include <netmeld/datastore/tools/AbstractImportJsonTool.hpp>
 
 #include "Parser.hpp"
 
@@ -40,7 +39,7 @@ using json = nlohmann::json;
 // Import tool definition
 // =============================================================================
 template<typename P, typename R>
-class Tool : public nmdt::AbstractImportSpiritTool<P,R>
+class Tool : public nmdt::AbstractImportJsonTool<P,R>
 {
   // ===========================================================================
   // Variables
@@ -56,7 +55,7 @@ class Tool : public nmdt::AbstractImportSpiritTool<P,R>
   private: // Constructors should rarely appear at this scope
   protected: // Constructors intended for internal/subclass API
   public: // Constructors should generally be public
-    Tool() : nmdt::AbstractImportSpiritTool<P,R>
+    Tool() : nmdt::AbstractImportJsonTool<P,R>
       (
        "aws ec2 describe-vpcs",  // command line tool imports data from
        PROGRAM_NAME,           // program name (set in CMakeLists.txt)
@@ -69,7 +68,7 @@ class Tool : public nmdt::AbstractImportSpiritTool<P,R>
   // Methods
   // ===========================================================================
   private: // Methods part of internal API
-    // Overriden from AbstractImportSpiritTool
+    // Overriden from AbstractImportJsonTool
     void
     addToolOptions() override
     {
@@ -84,25 +83,7 @@ class Tool : public nmdt::AbstractImportSpiritTool<P,R>
       this->opts.removeOptionalOption("device-color");
     }
 
-    // Overriden from AbstractImportSpiritTool
-    void
-    parseData() override
-    {
-      std::ifstream f {this->getDataPath().string()};
-
-      this->executionStart = nmco::Time();
-      try {
-        Parser parser;
-        parser.fromJson(json::parse(f));
-        this->tResults = parser.getData();
-      } catch (json::parse_error& ex) {
-        LOG_ERROR << "Parse error at byte " << ex.byte
-                  << std::endl;
-      }
-      this->executionStop = nmco::Time();
-    }
-
-    // Overriden from AbstractImportSpiritTool
+    // Overriden from AbstractImportJsonTool
     void
     specificInserts(pqxx::transaction_base& t) override
     {
@@ -131,6 +112,6 @@ class Tool : public nmdt::AbstractImportSpiritTool<P,R>
 // Program entry point
 // =============================================================================
 int main(int argc, char** argv) {
-  Tool<nmdp::DummyParser, Result> tool; // if parser not needed
+  Tool<Parser, Result> tool;
   return tool.start(argc, argv);
 }

--- a/datastore/importers/nmdb-import-aws-ec2-describe-vpcs/nmdb-import-aws-ec2-describe-vpcs.cpp
+++ b/datastore/importers/nmdb-import-aws-ec2-describe-vpcs/nmdb-import-aws-ec2-describe-vpcs.cpp
@@ -24,8 +24,6 @@
 // Maintained by Sandia National Laboratories <Netmeld@sandia.gov>
 // =============================================================================
 
-#include <nlohmann/json.hpp>
-
 #include <netmeld/datastore/tools/AbstractImportJsonTool.hpp>
 
 #include "Parser.hpp"

--- a/datastore/importers/nmdb-import-brocade-show-ip-route/nmdb-import-brocade-show-ip-route.cpp
+++ b/datastore/importers/nmdb-import-brocade-show-ip-route/nmdb-import-brocade-show-ip-route.cpp
@@ -24,7 +24,7 @@
 // Maintained by Sandia National Laboratories <Netmeld@sandia.gov>
 // =============================================================================
 
-#include <netmeld/datastore/tools/AbstractImportTool.hpp>
+#include <netmeld/datastore/tools/AbstractImportSpiritTool.hpp>
 
 #include "Parser.hpp"
 
@@ -32,7 +32,7 @@ namespace nmdt = netmeld::datastore::tools;
 
 
 template<typename P, typename R>
-class Tool : public nmdt::AbstractImportTool<P,R>
+class Tool : public nmdt::AbstractImportSpiritTool<P,R>
 {
   // ===========================================================================
   // Variables
@@ -48,7 +48,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
   private: // Constructors should rarely appear at this scope
   protected: // Constructors intended for internal/subclass API
   public: // Constructors should generally be public
-    Tool() : nmdt::AbstractImportTool<P,R>
+    Tool() : nmdt::AbstractImportSpiritTool<P,R>
       ("show ip route", PROGRAM_NAME, PROGRAM_VERSION)
     {}
 
@@ -57,7 +57,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
   // Methods
   // ===========================================================================
   private: // Methods part of internal API
-    // Overriden from AbstractImportTool
+    // Overriden from AbstractImportSpiritTool
     void
     specificInserts(pqxx::transaction_base& t) override
     {

--- a/datastore/importers/nmdb-import-brocade/nmdb-import-brocade.cpp
+++ b/datastore/importers/nmdb-import-brocade/nmdb-import-brocade.cpp
@@ -24,7 +24,7 @@
 // Maintained by Sandia National Laboratories <Netmeld@sandia.gov>
 // =============================================================================
 
-#include <netmeld/datastore/tools/AbstractImportTool.hpp>
+#include <netmeld/datastore/tools/AbstractImportSpiritTool.hpp>
 
 #include "Parser.hpp"
 
@@ -36,7 +36,7 @@ namespace nmdt = netmeld::datastore::tools;
 // Import tool definition
 // =============================================================================
 template<typename P, typename R>
-class Tool : public nmdt::AbstractImportTool<P,R>
+class Tool : public nmdt::AbstractImportSpiritTool<P,R>
 {
   // ===========================================================================
   // Variables
@@ -52,7 +52,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
   private: // Constructors should rarely appear at this scope
   protected: // Constructors intended for internal/subclass API
   public: // Constructors should generally be public
-    Tool() : nmdt::AbstractImportTool<P,R>
+    Tool() : nmdt::AbstractImportSpiritTool<P,R>
       (
        "configshow -all",  // command line tool imports data from
        PROGRAM_NAME,       // program name (set in CMakeLists.txt)
@@ -65,7 +65,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
   // Methods
   // ===========================================================================
   private: // Methods part of internal API
-    // Overriden from AbstractImportTool
+    // Overriden from AbstractImportSpiritTool
     void
     specificInserts(pqxx::transaction_base& t) override
     {

--- a/datastore/importers/nmdb-import-cisco-show-ip-route/nmdb-import-cisco-show-ip-route.cpp
+++ b/datastore/importers/nmdb-import-cisco-show-ip-route/nmdb-import-cisco-show-ip-route.cpp
@@ -25,7 +25,7 @@
 // =============================================================================
 
 #include <netmeld/datastore/objects/DeviceInformation.hpp>
-#include <netmeld/datastore/tools/AbstractImportTool.hpp>
+#include <netmeld/datastore/tools/AbstractImportSpiritTool.hpp>
 #include <boost/algorithm/string.hpp>
 
 #include "Parser.hpp"
@@ -35,7 +35,7 @@ namespace nmdt = netmeld::datastore::tools;
 
 
 template<typename P, typename R>
-class Tool : public nmdt::AbstractImportTool<P,R>
+class Tool : public nmdt::AbstractImportSpiritTool<P,R>
 {
   // ===========================================================================
   // Variables
@@ -51,7 +51,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
   private: // Constructors should rarely appear at this scope
   protected: // Constructors intended for internal/subclass API
   public: // Constructors should generally be public
-    Tool() : nmdt::AbstractImportTool<P,R>
+    Tool() : nmdt::AbstractImportSpiritTool<P,R>
       ("show ip route", PROGRAM_NAME, PROGRAM_VERSION)
     {}
 
@@ -60,7 +60,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
   // Methods
   // ===========================================================================
   private: // Methods part of internal API
-    // Overriden from AbstractImportTool
+    // Overriden from AbstractImportSpiritTool
     void
     specificInserts(pqxx::transaction_base& t) override
     {

--- a/datastore/importers/nmdb-import-cisco-wireless/Parser.hpp
+++ b/datastore/importers/nmdb-import-cisco-wireless/Parser.hpp
@@ -34,7 +34,7 @@
 #include <netmeld/datastore/parsers/ParserDomainName.hpp>
 #include <netmeld/datastore/parsers/ParserIpAddress.hpp>
 #include <netmeld/datastore/parsers/ParserMacAddress.hpp>
-#include <netmeld/datastore/tools/AbstractImportTool.hpp>
+#include <netmeld/datastore/tools/AbstractImportSpiritTool.hpp>
 
 
 namespace nmdo = netmeld::datastore::objects;

--- a/datastore/importers/nmdb-import-cisco-wireless/nmdb-import-cisco-wireless.cpp
+++ b/datastore/importers/nmdb-import-cisco-wireless/nmdb-import-cisco-wireless.cpp
@@ -24,7 +24,7 @@
 // Maintained by Sandia National Laboratories <Netmeld@sandia.gov>
 // =============================================================================
 
-#include <netmeld/datastore/tools/AbstractImportTool.hpp>
+#include <netmeld/datastore/tools/AbstractImportSpiritTool.hpp>
 
 #include "Parser.hpp"
 
@@ -36,7 +36,7 @@ namespace nmdu = netmeld::datastore::utils;
 // Import tool definition
 // =============================================================================
 template<typename P, typename R>
-class Tool : public nmdt::AbstractImportTool<P,R>
+class Tool : public nmdt::AbstractImportSpiritTool<P,R>
 {
   // ===========================================================================
   // Variables
@@ -52,7 +52,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
   private: // Constructors should rarely appear at this scope
   protected: // Constructors intended for internal/subclass API
   public: // Constructors should generally be public
-    Tool() : nmdt::AbstractImportTool<P,R>
+    Tool() : nmdt::AbstractImportSpiritTool<P,R>
       (
        "show run-config startup-commands",  // command line tool imports data from
        PROGRAM_NAME,           // program name (set in CMakeLists.txt)
@@ -65,7 +65,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
   // Methods
   // ===========================================================================
   private: // Methods part of internal API
-    // Overriden from AbstractImportTool
+    // Overriden from AbstractImportSpiritTool
     void
     specificInserts(pqxx::transaction_base& t) override
     {

--- a/datastore/importers/nmdb-import-cisco/Parser.hpp
+++ b/datastore/importers/nmdb-import-cisco/Parser.hpp
@@ -37,7 +37,7 @@
 #include <netmeld/datastore/parsers/ParserDomainName.hpp>
 #include <netmeld/datastore/parsers/ParserIpAddress.hpp>
 #include <netmeld/datastore/parsers/ParserMacAddress.hpp>
-#include <netmeld/datastore/tools/AbstractImportTool.hpp>
+#include <netmeld/datastore/tools/AbstractImportSpiritTool.hpp>
 
 #include "CiscoAcls.hpp"
 #include "CiscoNetworkBook.hpp"

--- a/datastore/importers/nmdb-import-cisco/nmdb-import-cisco.cpp
+++ b/datastore/importers/nmdb-import-cisco/nmdb-import-cisco.cpp
@@ -24,7 +24,7 @@
 // Maintained by Sandia National Laboratories <Netmeld@sandia.gov>
 // =============================================================================
 
-#include <netmeld/datastore/tools/AbstractImportTool.hpp>
+#include <netmeld/datastore/tools/AbstractImportSpiritTool.hpp>
 
 #include "Parser.hpp"
 
@@ -36,7 +36,7 @@ namespace nmdt = netmeld::datastore::tools;
 // Import tool definition
 // =============================================================================
 template<typename P, typename R>
-class Tool : public nmdt::AbstractImportTool<P,R>
+class Tool : public nmdt::AbstractImportSpiritTool<P,R>
 {
   // ===========================================================================
   // Variables
@@ -52,7 +52,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
   private: // Constructors should rarely appear at this scope
   protected: // Constructors intended for internal/subclass API
   public: // Constructors should generally be public
-    Tool() : nmdt::AbstractImportTool<P,R>
+    Tool() : nmdt::AbstractImportSpiritTool<P,R>
       (
        // command line tool imports data from
        "IOS|NXOS|ASA: show running-config all",
@@ -66,7 +66,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
   // Methods
   // ===========================================================================
   private: // Methods part of internal API
-    // Overriden from AbstractImportTool
+    // Overriden from AbstractImportSpiritTool
     void
     specificInserts(pqxx::transaction_base& t) override
     {

--- a/datastore/importers/nmdb-import-clw/nmdb-import-clw.cpp
+++ b/datastore/importers/nmdb-import-clw/nmdb-import-clw.cpp
@@ -25,7 +25,7 @@
 // =============================================================================
 
 #include <netmeld/datastore/parsers/ParserHelper.hpp>
-#include <netmeld/datastore/tools/AbstractImportTool.hpp>
+#include <netmeld/datastore/tools/AbstractImportSpiritTool.hpp>
 #include <netmeld/core/utils/ForkExec.hpp>
 
 typedef std::vector<std::string>  Results;
@@ -36,7 +36,7 @@ namespace nmcu = netmeld::core::utils;
 
 
 template<typename P, typename R>
-class Tool : public nmdt::AbstractImportTool<P,R>
+class Tool : public nmdt::AbstractImportSpiritTool<P,R>
 {
   private:
     std::string
@@ -51,7 +51,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
     }
 
   public:
-    Tool() : nmdt::AbstractImportTool<P,R>
+    Tool() : nmdt::AbstractImportSpiritTool<P,R>
       ("clw", PROGRAM_NAME, PROGRAM_VERSION)
     {}
 

--- a/datastore/importers/nmdb-import-dig/nmdb-import-dig.cpp
+++ b/datastore/importers/nmdb-import-dig/nmdb-import-dig.cpp
@@ -24,7 +24,7 @@
 // Maintained by Sandia National Laboratories <Netmeld@sandia.gov>
 // =============================================================================
 
-#include <netmeld/datastore/tools/AbstractImportTool.hpp>
+#include <netmeld/datastore/tools/AbstractImportSpiritTool.hpp>
 
 #include "Parser.hpp"
 
@@ -36,7 +36,7 @@ namespace nmdt = netmeld::datastore::tools;
 // Import tool definition
 // =============================================================================
 template<typename P, typename R>
-class Tool : public nmdt::AbstractImportTool<P,R>
+class Tool : public nmdt::AbstractImportSpiritTool<P,R>
 {
   // ===========================================================================
   // Variables
@@ -52,7 +52,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
   private: // Constructors should rarely appear at this scope
   protected: // Constructors intended for internal/subclass API
   public: // Constructors should generally be public
-    Tool() : nmdt::AbstractImportTool<P,R>
+    Tool() : nmdt::AbstractImportSpiritTool<P,R>
       (
        "dig",                 // command line tool imports data from
        PROGRAM_NAME,          // program name (set in CMakeLists.txt)
@@ -65,7 +65,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
   // Methods
   // ===========================================================================
   private: // Methods part of internal API
-    // Overriden from AbstractImportTool
+    // Overriden from AbstractImportSpiritTool
     void
     specificInserts(pqxx::transaction_base& t) override
     {

--- a/datastore/importers/nmdb-import-dpkg/nmdb-import-dpkg.cpp
+++ b/datastore/importers/nmdb-import-dpkg/nmdb-import-dpkg.cpp
@@ -24,7 +24,7 @@
 // Maintained by Sandia National Laboratories <Netmeld@sandia.gov>
 // =============================================================================
 
-#include <netmeld/datastore/tools/AbstractImportTool.hpp>
+#include <netmeld/datastore/tools/AbstractImportSpiritTool.hpp>
 #include "Parser.hpp"
 
 namespace nmdt = netmeld::datastore::tools;
@@ -33,7 +33,7 @@ namespace nmdt = netmeld::datastore::tools;
 // Import tool definition
 // =============================================================================
 template<typename P, typename R>
-class Tool : public nmdt::AbstractImportTool<P,R>
+class Tool : public nmdt::AbstractImportSpiritTool<P,R>
 {
   // ===========================================================================
   // Variables
@@ -48,7 +48,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
   private:
   protected:
   public:
-    Tool() : nmdt::AbstractImportTool<P,R>
+    Tool() : nmdt::AbstractImportSpiritTool<P,R>
       (
        "dpkg -l",  // command line tool imports data from
        PROGRAM_NAME,           // program name (set in CMakeLists.txt)

--- a/datastore/importers/nmdb-import-f5-json/Parser.cpp
+++ b/datastore/importers/nmdb-import-f5-json/Parser.cpp
@@ -41,10 +41,35 @@ namespace nmdp = netmeld::datastore::parsers;
 namespace nmdu = netmeld::datastore::utils;
 
 
-Data
+Result
 Parser::getData()
 {
-  return data;
+  Result r;
+  r.emplace_back(data);
+  return r;
+}
+
+void
+Parser::fromJson(const nlohmann::json &doc)
+{
+  const std::string docKind{doc.at("kind").get<std::string>()};
+
+  if ("tm:ltm:virtual-address:virtual-addresscollectionstate" == docKind) {
+    parseLtmVirtualAddress(doc);
+  }
+  else if (("tm:net:arp:arpcollectionstate" == docKind) ||
+           ("tm:net:ndp:ndpcollectionstate" == docKind)) {
+    parseNetArpNdp(doc);
+  }
+  else if ("tm:net:self:selfcollectionstate" == docKind) {
+    parseNetSelf(doc);
+  }
+  else if ("tm:net:route:routecollectionstate" == docKind) {
+    parseNetRoute(doc);
+  }
+  else {
+    parseUnsupported(doc);
+  }
 }
 
 

--- a/datastore/importers/nmdb-import-f5-json/Parser.hpp
+++ b/datastore/importers/nmdb-import-f5-json/Parser.hpp
@@ -50,6 +50,7 @@
 #include <tuple>
 #include <vector>
 
+using json = nlohmann::json;
 
 struct LogicalSystem
 {
@@ -72,13 +73,17 @@ struct Data
   std::map<std::string, LogicalSystem> logicalSystems;
   netmeld::datastore::objects::ToolObservations observations;
 };
+typedef std::vector<Data>    Result;
 
 
 class Parser
 {
   public:
-    Data
+    Result
     getData();
+
+    void
+    fromJson(const json&);
 
     void
     parseLtmVirtualAddress(const nlohmann::ordered_json&);

--- a/datastore/importers/nmdb-import-f5-json/nmdb-import-f5-json.cpp
+++ b/datastore/importers/nmdb-import-f5-json/nmdb-import-f5-json.cpp
@@ -24,7 +24,7 @@
 // Maintained by Sandia National Laboratories <Netmeld@sandia.gov>
 // =============================================================================
 
-#include <netmeld/datastore/tools/AbstractImportTool.hpp>
+#include <netmeld/datastore/tools/AbstractImportSpiritTool.hpp>
 #include <nlohmann/json.hpp>
 #include <fstream>
 
@@ -39,10 +39,10 @@ typedef std::vector<Data> Results;
 
 
 template<typename P, typename R>
-class Tool : public nmdt::AbstractImportTool<P,R>
+class Tool : public nmdt::AbstractImportSpiritTool<P,R>
 {
   public:
-    Tool() : nmdt::AbstractImportTool<P,R>
+    Tool() : nmdt::AbstractImportSpiritTool<P,R>
       ("F5 REST API JSON output (.json files)", PROGRAM_NAME, PROGRAM_VERSION)
     {
       this->devInfo.setVendor("F5");

--- a/datastore/importers/nmdb-import-f5-json/nmdb-import-f5-json.cpp
+++ b/datastore/importers/nmdb-import-f5-json/nmdb-import-f5-json.cpp
@@ -24,9 +24,7 @@
 // Maintained by Sandia National Laboratories <Netmeld@sandia.gov>
 // =============================================================================
 
-#include <netmeld/datastore/tools/AbstractImportSpiritTool.hpp>
-#include <nlohmann/json.hpp>
-#include <fstream>
+#include <netmeld/datastore/tools/AbstractImportJsonTool.hpp>
 
 #include "Parser.hpp"
 
@@ -39,43 +37,13 @@ typedef std::vector<Data> Results;
 
 
 template<typename P, typename R>
-class Tool : public nmdt::AbstractImportSpiritTool<P,R>
+class Tool : public nmdt::AbstractImportJsonTool<P,R>
 {
   public:
-    Tool() : nmdt::AbstractImportSpiritTool<P,R>
+    Tool() : nmdt::AbstractImportJsonTool<P,R>
       ("F5 REST API JSON output (.json files)", PROGRAM_NAME, PROGRAM_VERSION)
     {
       this->devInfo.setVendor("F5");
-    }
-
-    void
-    parseData() override
-    {
-      std::ifstream f(this->getDataPath().string());
-      nlohmann::ordered_json doc = nlohmann::ordered_json::parse(f);
-
-      Parser parser;
-
-      const std::string docKind{doc.at("kind").get<std::string>()};
-
-      if ("tm:ltm:virtual-address:virtual-addresscollectionstate" == docKind) {
-        parser.parseLtmVirtualAddress(doc);
-      }
-      else if (("tm:net:arp:arpcollectionstate" == docKind) ||
-               ("tm:net:ndp:ndpcollectionstate" == docKind)) {
-        parser.parseNetArpNdp(doc);
-      }
-      else if ("tm:net:self:selfcollectionstate" == docKind) {
-        parser.parseNetSelf(doc);
-      }
-      else if ("tm:net:route:routecollectionstate" == docKind) {
-        parser.parseNetRoute(doc);
-      }
-      else {
-        parser.parseUnsupported(doc);
-      }
-
-      this->tResults.emplace_back(parser.getData());
     }
 
     void
@@ -167,7 +135,7 @@ class Tool : public nmdt::AbstractImportSpiritTool<P,R>
 int
 main(int argc, char** argv)
 {
-  Tool<nmdp::DummyParser, Results> tool;
+  Tool<Parser, Results> tool;
   return tool.start(argc, argv);
 }
 

--- a/datastore/importers/nmdb-import-hosts/nmdb-import-hosts.cpp
+++ b/datastore/importers/nmdb-import-hosts/nmdb-import-hosts.cpp
@@ -24,7 +24,7 @@
 // Maintained by Sandia National Laboratories <Netmeld@sandia.gov>
 // =============================================================================
 
-#include <netmeld/datastore/tools/AbstractImportTool.hpp>
+#include <netmeld/datastore/tools/AbstractImportSpiritTool.hpp>
 
 #include "Parser.hpp"
 
@@ -37,7 +37,7 @@ namespace nmdt = netmeld::datastore::tools;
 // Import tool definition
 // =============================================================================
 template<typename P, typename R>
-class Tool : public nmdt::AbstractImportTool<P,R>
+class Tool : public nmdt::AbstractImportSpiritTool<P,R>
 {
   // ===========================================================================
   // Variables
@@ -49,7 +49,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
       // std::string            programName;
       // std::string            version;
       // ProgramOptions         opts;
-    // Inhertied from AbstractImportTool at this scope
+    // Inhertied from AbstractImportSpiritTool at this scope
       // TResults                 tResults;
       // nmco::Uuid               toolRunId;
       // nmco::Time               executionStart;
@@ -64,7 +64,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
   private: // Constructors should rarely appear at this scope
   protected: // Constructors intended for internal/subclass API
   public: // Constructors should generally be public
-    Tool() : nmdt::AbstractImportTool<P,R>
+    Tool() : nmdt::AbstractImportSpiritTool<P,R>
       (
        "cat /etc/hosts",  // command line tool imports data from
        PROGRAM_NAME,      // program name (set in CMakeLists.txt)
@@ -78,7 +78,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
   // ===========================================================================
   private: // Methods part of internal API
 
-    // Overriden from AbstractImportTool
+    // Overriden from AbstractImportSpiritTool
     void
     specificInserts(pqxx::transaction_base& t) override
     {
@@ -95,7 +95,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
     // Inherited from AbstractTool at this scope
       // std::string const getDbName() const;
       // virtual void printVersion() const;
-    // Inherited from AbstractImportTool at this scope
+    // Inherited from AbstractImportSpiritTool at this scope
       // fs::path    const getDataPath() const;
       // std::string const getDeviceId() const;
       // nmco::Uuid   const getToolRunId() const;

--- a/datastore/importers/nmdb-import-ip-addr-show/nmdb-import-ip-addr-show.cpp
+++ b/datastore/importers/nmdb-import-ip-addr-show/nmdb-import-ip-addr-show.cpp
@@ -24,7 +24,7 @@
 // Maintained by Sandia National Laboratories <Netmeld@sandia.gov>
 // =============================================================================
 
-#include <netmeld/datastore/tools/AbstractImportTool.hpp>
+#include <netmeld/datastore/tools/AbstractImportSpiritTool.hpp>
 
 #include "Parser.hpp"
 
@@ -32,10 +32,10 @@ namespace nmdt = netmeld::datastore::tools;
 
 
 template<typename P, typename R>
-class Tool : public nmdt::AbstractImportTool<P,R>
+class Tool : public nmdt::AbstractImportSpiritTool<P,R>
 {
   public:
-    Tool() : nmdt::AbstractImportTool<P,R>
+    Tool() : nmdt::AbstractImportSpiritTool<P,R>
       ("ip addr show", PROGRAM_NAME, PROGRAM_VERSION)
     {}
 

--- a/datastore/importers/nmdb-import-ip-route-show/nmdb-import-ip-route-show.cpp
+++ b/datastore/importers/nmdb-import-ip-route-show/nmdb-import-ip-route-show.cpp
@@ -24,7 +24,7 @@
 // Maintained by Sandia National Laboratories <Netmeld@sandia.gov>
 // =============================================================================
 
-#include <netmeld/datastore/tools/AbstractImportTool.hpp>
+#include <netmeld/datastore/tools/AbstractImportSpiritTool.hpp>
 #include "Parser.hpp"
 
 namespace nmdt = netmeld::datastore::tools;
@@ -34,7 +34,7 @@ namespace nmdt = netmeld::datastore::tools;
 // Import tool definition
 // =============================================================================
 template<typename P, typename R>
-class Tool : public nmdt::AbstractImportTool<P,R>
+class Tool : public nmdt::AbstractImportSpiritTool<P,R>
 {
   // ===========================================================================
   // Variables
@@ -50,7 +50,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
   private: // Constructors should rarely appear at this scope
   protected: // Constructors intended for internal/subclass API
   public: // Constructors should generally be public
-    Tool() : nmdt::AbstractImportTool<P,R>
+    Tool() : nmdt::AbstractImportSpiritTool<P,R>
       (
        "ip route show",    // command line tool imports data from
        PROGRAM_NAME,       // program name (set in CMakeLists.txt)
@@ -63,7 +63,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
   // Methods
   // ===========================================================================
   private: // Methods part of internal API
-    // Overriden from AbstractImportTool
+    // Overriden from AbstractImportSpiritTool
     void toolRunMetadataInserts(pqxx::transaction_base& t) override
     {
       const auto& toolRunId {this->getToolRunId()};

--- a/datastore/importers/nmdb-import-ipconfig/nmdb-import-ipconfig.cpp
+++ b/datastore/importers/nmdb-import-ipconfig/nmdb-import-ipconfig.cpp
@@ -24,7 +24,7 @@
 // Maintained by Sandia National Laboratories <Netmeld@sandia.gov>
 // =============================================================================
 
-#include <netmeld/datastore/tools/AbstractImportTool.hpp>
+#include <netmeld/datastore/tools/AbstractImportSpiritTool.hpp>
 
 #include "Parser.hpp"
 
@@ -32,10 +32,10 @@ namespace nmdt = netmeld::datastore::tools;
 
 
 template<typename P, typename R>
-class Tool : public nmdt::AbstractImportTool<P,R>
+class Tool : public nmdt::AbstractImportSpiritTool<P,R>
 {
   public:
-    Tool() : nmdt::AbstractImportTool<P,R>
+    Tool() : nmdt::AbstractImportSpiritTool<P,R>
       ("ipconfig [/allcompartments /all] [/all]", PROGRAM_NAME, PROGRAM_VERSION)
     {}
 

--- a/datastore/importers/nmdb-import-iptables-save/nmdb-import-iptables-save.cpp
+++ b/datastore/importers/nmdb-import-iptables-save/nmdb-import-iptables-save.cpp
@@ -24,7 +24,7 @@
 // Maintained by Sandia National Laboratories <Netmeld@sandia.gov>
 // =============================================================================
 
-#include <netmeld/datastore/tools/AbstractImportTool.hpp>
+#include <netmeld/datastore/tools/AbstractImportSpiritTool.hpp>
 
 #include "Parser.hpp"
 
@@ -36,7 +36,7 @@ namespace nmdt = netmeld::datastore::tools;
 // Import tool definition
 // =============================================================================
 template<typename P, typename R>
-class Tool : public nmdt::AbstractImportTool<P, R>
+class Tool : public nmdt::AbstractImportSpiritTool<P, R>
 {
   // ===========================================================================
   // Variables
@@ -52,7 +52,7 @@ class Tool : public nmdt::AbstractImportTool<P, R>
   private: // Constructors should rarely appear at this scope
   protected: // Constructors intended for internal/subclass API
   public: // Constructors should generally be public
-    Tool() : nmdt::AbstractImportTool<P, R>
+    Tool() : nmdt::AbstractImportSpiritTool<P, R>
       (
        "iptables-save -c",  // command line tool imports data from
        PROGRAM_NAME,           // program name (set in CMakeLists.txt)
@@ -64,7 +64,7 @@ class Tool : public nmdt::AbstractImportTool<P, R>
   // Methods
   // ===========================================================================
   private: // Methods part of internal API
-    // Overriden from AbstractImportTool
+    // Overriden from AbstractImportSpiritTool
     void
     specificInserts(pqxx::transaction_base& t) override
     {

--- a/datastore/importers/nmdb-import-juniper-conf/nmdb-import-juniper-conf.cpp
+++ b/datastore/importers/nmdb-import-juniper-conf/nmdb-import-juniper-conf.cpp
@@ -24,7 +24,7 @@
 // Maintained by Sandia National Laboratories <Netmeld@sandia.gov>
 // =============================================================================
 
-#include <netmeld/datastore/tools/AbstractImportTool.hpp>
+#include <netmeld/datastore/tools/AbstractImportSpiritTool.hpp>
 
 #include "Parser.hpp"
 
@@ -36,7 +36,7 @@ namespace nmdt = netmeld::datastore::tools;
 // Import tool definition
 // =============================================================================
 template<typename P, typename R>
-class Tool : public nmdt::AbstractImportTool<P,R>
+class Tool : public nmdt::AbstractImportSpiritTool<P,R>
 {
   // ===========================================================================
   // Variables
@@ -52,7 +52,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
   private: // Constructors should rarely appear at this scope
   protected: // Constructors intended for internal/subclass API
   public: // Constructors should generally be public
-    Tool() : nmdt::AbstractImportTool<P,R>
+    Tool() : nmdt::AbstractImportSpiritTool<P,R>
       (
        "show configuration",  // command line tool imports data from
        PROGRAM_NAME,          // program name (set in CMakeLists.txt)
@@ -65,7 +65,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
   // Methods
   // ===========================================================================
   private: // Methods part of internal API
-    // Overriden from AbstractImportTool
+    // Overriden from AbstractImportSpiritTool
     void
     specificInserts(pqxx::transaction_base& t) override
     {

--- a/datastore/importers/nmdb-import-juniper-set/nmdb-import-juniper-set.cpp
+++ b/datastore/importers/nmdb-import-juniper-set/nmdb-import-juniper-set.cpp
@@ -24,7 +24,7 @@
 // Maintained by Sandia National Laboratories <Netmeld@sandia.gov>
 // =============================================================================
 
-#include <netmeld/datastore/tools/AbstractImportTool.hpp>
+#include <netmeld/datastore/tools/AbstractImportSpiritTool.hpp>
 
 #include "Parser.hpp"
 
@@ -36,7 +36,7 @@ namespace nmdt = netmeld::datastore::tools;
 // Import tool definition
 // =============================================================================
 template<typename P, typename R>
-class Tool : public nmdt::AbstractImportTool<P,R>
+class Tool : public nmdt::AbstractImportSpiritTool<P,R>
 {
   // ===========================================================================
   // Variables
@@ -52,7 +52,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
   private: // Constructors should rarely appear at this scope
   protected: // Constructors intended for internal/subclass API
   public: // Constructors should generally be public
-    Tool() : nmdt::AbstractImportTool<P,R>
+    Tool() : nmdt::AbstractImportSpiritTool<P,R>
       (
        "get config",    // command line tool imports data from
        PROGRAM_NAME,    // program name (set in CMakeLists.txt)

--- a/datastore/importers/nmdb-import-juniper-show-route/nmdb-import-juniper-show-route.cpp
+++ b/datastore/importers/nmdb-import-juniper-show-route/nmdb-import-juniper-show-route.cpp
@@ -25,7 +25,7 @@
 // =============================================================================
 
 #include <netmeld/datastore/objects/DeviceInformation.hpp>
-#include <netmeld/datastore/tools/AbstractImportTool.hpp>
+#include <netmeld/datastore/tools/AbstractImportSpiritTool.hpp>
 #include <boost/algorithm/string.hpp>
 
 #include "Parser.hpp"
@@ -35,7 +35,7 @@ namespace nmdt = netmeld::datastore::tools;
 
 
 template<typename P, typename R>
-class Tool : public nmdt::AbstractImportTool<P,R>
+class Tool : public nmdt::AbstractImportSpiritTool<P,R>
 {
   // ===========================================================================
   // Variables
@@ -51,7 +51,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
   private: // Constructors should rarely appear at this scope
   protected: // Constructors intended for internal/subclass API
   public: // Constructors should generally be public
-    Tool() : nmdt::AbstractImportTool<P,R>
+    Tool() : nmdt::AbstractImportSpiritTool<P,R>
       ("show route logical-system all | no-more",
        PROGRAM_NAME, PROGRAM_VERSION)
     {}
@@ -61,7 +61,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
   // Methods
   // ===========================================================================
   private: // Methods part of internal API
-    // Overriden from AbstractImportTool
+    // Overriden from AbstractImportSpiritTool
     void
     specificInserts(pqxx::transaction_base& t) override
     {

--- a/datastore/importers/nmdb-import-juniper-xml/Parser.cpp
+++ b/datastore/importers/nmdb-import-juniper-xml/Parser.cpp
@@ -73,41 +73,41 @@ Parser::handleXML(const pugi::xml_document& doc)
   for (const pugi::xml_node dataNode : rpcReplyNode.children()) {
     const std::string dataNodeName{dataNode.name()};
     if ("arp-table-information" == dataNodeName) {
-      this->parseArpTableInfo(dataNode);
+      parseArpTableInfo(dataNode);
     }
     else if ("cli" == dataNodeName) {
       // Ignored: Metadata for the command-line interface.
     }
     else if ("configuration" == dataNodeName) {
-      this->parseConfig(dataNode);
+      parseConfig(dataNode);
     }
     else if ("ipv6-nd-information" == dataNodeName) {
-      this->parseIpv6NeighborInfo(dataNode);
+      parseIpv6NeighborInfo(dataNode);
     }
     else if (("l2ng-l2ald-rtb-mac-ip-db" == dataNodeName) ||
              ("l2ng-l2ald-rtb-macdb"     == dataNodeName) ||
              ("l2ng-l2rtb-evpn-arp-db"   == dataNodeName) ||
              ("l2ng-l2rtb-evpn-nd-db"    == dataNodeName)) {
-      this->parseEthernetSwitching(dataNode);
+      parseEthernetSwitching(dataNode);
     }
     else if ("lldp-neighbors-information" == dataNodeName) {
-      this->parseLldpNeighborInfo(dataNode);
+      parseLldpNeighborInfo(dataNode);
     }
     else if ("output" == dataNodeName) {
       // Ignored: Context-specific text for the device to output.
       // Either ignored or handled in the parser for another element.
     }
     else if ("route-information" == dataNodeName) {
-      this->parseRouteInfo(dataNode);
+      parseRouteInfo(dataNode);
     }
     else if ("xnm:error" == dataNodeName) {
-      this->parseError(dataNode);
+      parseError(dataNode);
     }
     else if ("xnm:warning" == dataNodeName) {
-      this->parseWarning(dataNode);
+      parseWarning(dataNode);
     }
     else {
-      this->parseUnsupported(dataNode);
+      parseUnsupported(dataNode);
     }
   }
 }

--- a/datastore/importers/nmdb-import-juniper-xml/Parser.hpp
+++ b/datastore/importers/nmdb-import-juniper-xml/Parser.hpp
@@ -77,12 +77,17 @@ struct Data
   netmeld::datastore::objects::ToolObservations observations;
 };
 
+typedef std::vector<Data> Results;
+
 
 class Parser
 {
   public:
-    Data
+    Results
     getData();
+
+    void
+    handleXML(const pugi::xml_document& doc);
 
     void
     parseConfig(const pugi::xml_node& configNode);

--- a/datastore/importers/nmdb-import-juniper-xml/nmdb-import-juniper-xml.cpp
+++ b/datastore/importers/nmdb-import-juniper-xml/nmdb-import-juniper-xml.cpp
@@ -25,7 +25,6 @@
 // =============================================================================
 
 #include <netmeld/datastore/tools/AbstractImportXMLTool.hpp>
-#include <pugixml.hpp>
 
 #include "Parser.hpp"
 

--- a/datastore/importers/nmdb-import-juniper-xml/nmdb-import-juniper-xml.cpp
+++ b/datastore/importers/nmdb-import-juniper-xml/nmdb-import-juniper-xml.cpp
@@ -24,7 +24,7 @@
 // Maintained by Sandia National Laboratories <Netmeld@sandia.gov>
 // =============================================================================
 
-#include <netmeld/datastore/tools/AbstractImportXMLTool.hpp>
+#include <netmeld/datastore/tools/AbstractImportXmlTool.hpp>
 
 #include "Parser.hpp"
 
@@ -37,10 +37,10 @@ typedef std::vector<Data> Results;
 
 
 template<typename P, typename R>
-class Tool : public nmdt::AbstractImportXMLTool<P,R>
+class Tool : public nmdt::AbstractImportXmlTool<P,R>
 {
   public:
-    Tool() : nmdt::AbstractImportXMLTool<P,R>
+    Tool() : nmdt::AbstractImportXmlTool<P,R>
       ("Juniper XML output (.xml files)", PROGRAM_NAME, PROGRAM_VERSION)
     {
       this->devInfo.setVendor("Juniper");

--- a/datastore/importers/nmdb-import-nessus/nmdb-import-nessus.cpp
+++ b/datastore/importers/nmdb-import-nessus/nmdb-import-nessus.cpp
@@ -36,7 +36,7 @@
 #include <netmeld/datastore/objects/TracerouteHop.hpp>
 #include <netmeld/datastore/parsers/ParserHelper.hpp>
 #include <netmeld/datastore/parsers/ParserIpAddress.hpp>
-#include <netmeld/datastore/tools/AbstractImportTool.hpp>
+#include <netmeld/datastore/tools/AbstractImportSpiritTool.hpp>
 
 #include "InterfaceHelper.hpp"
 #include "MetasploitModule.hpp"
@@ -64,10 +64,10 @@ typedef std::vector<Data>             Results;
 
 
 template<typename P, typename R>
-class Tool : public nmdt::AbstractImportTool<P,R>
+class Tool : public nmdt::AbstractImportSpiritTool<P,R>
 {
   public:
-    Tool() : nmdt::AbstractImportTool<P,R>
+    Tool() : nmdt::AbstractImportSpiritTool<P,R>
       ("Nessus's XML output (.nessus file)", PROGRAM_NAME, PROGRAM_VERSION)
     {}
 

--- a/datastore/importers/nmdb-import-nmap/ParserNmapXml.hpp
+++ b/datastore/importers/nmdb-import-nmap/ParserNmapXml.hpp
@@ -37,7 +37,6 @@
 #include <netmeld/datastore/objects/ToolObservations.hpp>
 #include <netmeld/datastore/objects/TracerouteHop.hpp>
 #include <netmeld/datastore/parsers/ParserHelper.hpp>
-#include <netmeld/datastore/tools/AbstractImportSpiritTool.hpp>
 
 #include "NseResult.hpp"
 #include "SshAlgorithm.hpp"
@@ -45,7 +44,6 @@
 
 namespace nmdo = netmeld::datastore::objects;
 namespace nmdp = netmeld::datastore::parsers;
-namespace nmdt = netmeld::datastore::tools;
 namespace nmdu = netmeld::datastore::utils;
 
 // =============================================================================

--- a/datastore/importers/nmdb-import-nmap/ParserNmapXml.hpp
+++ b/datastore/importers/nmdb-import-nmap/ParserNmapXml.hpp
@@ -37,7 +37,7 @@
 #include <netmeld/datastore/objects/ToolObservations.hpp>
 #include <netmeld/datastore/objects/TracerouteHop.hpp>
 #include <netmeld/datastore/parsers/ParserHelper.hpp>
-#include <netmeld/datastore/tools/AbstractImportTool.hpp>
+#include <netmeld/datastore/tools/AbstractImportSpiritTool.hpp>
 
 #include "NseResult.hpp"
 #include "SshAlgorithm.hpp"

--- a/datastore/importers/nmdb-import-nmap/nmdb-import-nmap.cpp
+++ b/datastore/importers/nmdb-import-nmap/nmdb-import-nmap.cpp
@@ -30,7 +30,7 @@
 
 #include <netmeld/datastore/objects/IpAddress.hpp>
 #include <netmeld/datastore/parsers/ParserHelper.hpp>
-#include <netmeld/datastore/tools/AbstractImportTool.hpp>
+#include <netmeld/datastore/tools/AbstractImportSpiritTool.hpp>
 
 #include "ParserNmapXml.hpp"
 
@@ -41,10 +41,10 @@ namespace nmdu = netmeld::datastore::utils;
 
 
 template<typename P, typename R>
-class Tool : public nmdt::AbstractImportTool<P,R>
+class Tool : public nmdt::AbstractImportSpiritTool<P,R>
 {
   public:
-    Tool() : nmdt::AbstractImportTool<P,R>
+    Tool() : nmdt::AbstractImportSpiritTool<P,R>
       ("Nmap's XML output (.xml files)", PROGRAM_NAME, PROGRAM_VERSION)
     {}
 

--- a/datastore/importers/nmdb-import-paloalto-xml/nmdb-import-paloalto-xml.cpp
+++ b/datastore/importers/nmdb-import-paloalto-xml/nmdb-import-paloalto-xml.cpp
@@ -24,7 +24,7 @@
 // Maintained by Sandia National Laboratories <Netmeld@sandia.gov>
 // =============================================================================
 
-#include <netmeld/datastore/tools/AbstractImportTool.hpp>
+#include <netmeld/datastore/tools/AbstractImportSpiritTool.hpp>
 #include <pugixml.hpp>
 
 #include "Parser.hpp"
@@ -38,10 +38,10 @@ typedef std::vector<Data> Results;
 
 
 template<typename P, typename R>
-class Tool : public nmdt::AbstractImportTool<P,R>
+class Tool : public nmdt::AbstractImportSpiritTool<P,R>
 {
   public:
-    Tool() : nmdt::AbstractImportTool<P,R>
+    Tool() : nmdt::AbstractImportSpiritTool<P,R>
       ("Palo Alto XML output (.xml files)", PROGRAM_NAME, PROGRAM_VERSION)
     {
       this->devInfo.setVendor("Palo Alto");

--- a/datastore/importers/nmdb-import-pcap/nmdb-import-pcap.cpp
+++ b/datastore/importers/nmdb-import-pcap/nmdb-import-pcap.cpp
@@ -24,7 +24,7 @@
 // Maintained by Sandia National Laboratories <Netmeld@sandia.gov>
 // =============================================================================
 
-#include <netmeld/datastore/tools/AbstractImportTool.hpp>
+#include <netmeld/datastore/tools/AbstractImportSpiritTool.hpp>
 #include <netmeld/datastore/parsers/ParserHelper.hpp>
 
 #include "Parser.hpp"
@@ -35,10 +35,10 @@ namespace nmdt = netmeld::datastore::tools;
 
 
 template<typename P, typename R>
-class Tool : public nmdt::AbstractImportTool<P,R>
+class Tool : public nmdt::AbstractImportSpiritTool<P,R>
 {
   public:
-    Tool() : nmdt::AbstractImportTool<P,R>
+    Tool() : nmdt::AbstractImportSpiritTool<P,R>
       ("pcap file", PROGRAM_NAME, PROGRAM_VERSION)
     {}
 

--- a/datastore/importers/nmdb-import-ping/Parser.hpp
+++ b/datastore/importers/nmdb-import-ping/Parser.hpp
@@ -30,12 +30,9 @@
 #include <netmeld/datastore/objects/IpAddress.hpp>
 #include <netmeld/datastore/parsers/ParserDomainName.hpp>
 #include <netmeld/datastore/parsers/ParserIpAddress.hpp>
-#include <netmeld/datastore/tools/AbstractImportSpiritTool.hpp>
 
 namespace nmdo = netmeld::datastore::objects;
 namespace nmdp = netmeld::datastore::parsers;
-namespace nmdt = netmeld::datastore::tools;
-
 
 // =============================================================================
 // Data containers

--- a/datastore/importers/nmdb-import-ping/Parser.hpp
+++ b/datastore/importers/nmdb-import-ping/Parser.hpp
@@ -30,7 +30,7 @@
 #include <netmeld/datastore/objects/IpAddress.hpp>
 #include <netmeld/datastore/parsers/ParserDomainName.hpp>
 #include <netmeld/datastore/parsers/ParserIpAddress.hpp>
-#include <netmeld/datastore/tools/AbstractImportTool.hpp>
+#include <netmeld/datastore/tools/AbstractImportSpiritTool.hpp>
 
 namespace nmdo = netmeld::datastore::objects;
 namespace nmdp = netmeld::datastore::parsers;

--- a/datastore/importers/nmdb-import-ping/nmdb-import-ping.cpp
+++ b/datastore/importers/nmdb-import-ping/nmdb-import-ping.cpp
@@ -24,7 +24,7 @@
 // Maintained by Sandia National Laboratories <Netmeld@sandia.gov>
 // =============================================================================
 
-#include <netmeld/datastore/tools/AbstractImportTool.hpp>
+#include <netmeld/datastore/tools/AbstractImportSpiritTool.hpp>
 
 #include "Parser.hpp"
 
@@ -36,7 +36,7 @@ namespace nmdt = netmeld::datastore::tools;
 // Import tool definition
 // =============================================================================
 template<typename P, typename R>
-class Tool : public nmdt::AbstractImportTool<P, R>
+class Tool : public nmdt::AbstractImportSpiritTool<P, R>
 {
   // ===========================================================================
   // Variables
@@ -52,7 +52,7 @@ class Tool : public nmdt::AbstractImportTool<P, R>
   private: // Constructors should rarely appear at this scope
   protected: // Constructors intended for internal/subclass API
   public: // Constructors should generally be public
-    Tool() : nmdt::AbstractImportTool<P, R>
+    Tool() : nmdt::AbstractImportSpiritTool<P, R>
       ("ping -n",       // command line tool imports data from
        PROGRAM_NAME,    // program name (set in CMakeLists.txt)
        PROGRAM_VERSION  // program version (set in CMakeLists.txt)
@@ -64,7 +64,7 @@ class Tool : public nmdt::AbstractImportTool<P, R>
   // Methods
   // ===========================================================================
   private: // Methods part of internal API
-    // Overriden from AbstractImportTool
+    // Overriden from AbstractImportSpiritTool
     void
     addToolOptions() override
     {
@@ -76,7 +76,7 @@ class Tool : public nmdt::AbstractImportTool<P, R>
         );
     }
 
-    // Overriden from AbstractImportTool
+    // Overriden from AbstractImportSpiritTool
     void
     specificInserts(pqxx::transaction_base& t) override
     {

--- a/datastore/importers/nmdb-import-powerconnect/nmdb-import-powerconnect.cpp
+++ b/datastore/importers/nmdb-import-powerconnect/nmdb-import-powerconnect.cpp
@@ -24,7 +24,7 @@
 // Maintained by Sandia National Laboratories <Netmeld@sandia.gov>
 // =============================================================================
 
-#include <netmeld/datastore/tools/AbstractImportTool.hpp>
+#include <netmeld/datastore/tools/AbstractImportSpiritTool.hpp>
 
 #include "Parser.hpp"
 
@@ -36,7 +36,7 @@ namespace nmdt = netmeld::datastore::tools;
 // Import tool definition
 // =============================================================================
 template<typename P, typename R>
-class Tool : public nmdt::AbstractImportTool<P,R>
+class Tool : public nmdt::AbstractImportSpiritTool<P,R>
 {
   // ===========================================================================
   // Variables
@@ -52,7 +52,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
   private: // Constructors should rarely appear at this scope
   protected: // Constructors intended for internal/subclass API
   public: // Constructors should generally be public
-    Tool() : nmdt::AbstractImportTool<P,R>
+    Tool() : nmdt::AbstractImportSpiritTool<P,R>
       (
        "show running-config",  // command line tool imports data from
        PROGRAM_NAME,           // program name (set in CMakeLists.txt)
@@ -65,7 +65,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
   // Methods
   // ===========================================================================
   private: // Methods part of internal API
-    // Overriden from AbstractImportTool
+    // Overriden from AbstractImportSpiritTool
     void
     specificInserts(pqxx::transaction_base& t) override
     {

--- a/datastore/importers/nmdb-import-prowler/nmdb-import-prowler.cpp
+++ b/datastore/importers/nmdb-import-prowler/nmdb-import-prowler.cpp
@@ -24,7 +24,7 @@
 // Maintained by Sandia National Laboratories <Netmeld@sandia.gov>
 // =============================================================================
 
-#include <netmeld/datastore/tools/AbstractImportTool.hpp>
+#include <netmeld/datastore/tools/AbstractImportSpiritTool.hpp>
 #include <netmeld/datastore/parsers/ParserHelper.hpp> // if parser not needed
 
 #include "Parser.hpp"
@@ -37,7 +37,7 @@ namespace nmdt = netmeld::datastore::tools;
 // Import tool definition
 // =============================================================================
 template<typename P, typename R>
-class Tool : public nmdt::AbstractImportTool<P,R>
+class Tool : public nmdt::AbstractImportSpiritTool<P,R>
 {
   // ===========================================================================
   // Variables
@@ -53,7 +53,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
   private: // Constructors should rarely appear at this scope
   protected: // Constructors intended for internal/subclass API
   public: // Constructors should generally be public
-    Tool() : nmdt::AbstractImportTool<P,R>
+    Tool() : nmdt::AbstractImportSpiritTool<P,R>
       (
        "prowler -M json",  // command line tool imports data from
        PROGRAM_NAME,       // program name (set in CMakeLists.txt)
@@ -66,7 +66,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
   // Methods
   // ===========================================================================
   private: // Methods part of internal API
-    // Overriden from AbstractImportTool
+    // Overriden from AbstractImportSpiritTool
     void
     addToolOptions() override
     {
@@ -97,7 +97,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
       this->executionStop = nmco::Time();
     }
 
-    // Overriden from AbstractImportTool
+    // Overriden from AbstractImportSpiritTool
     void
     specificInserts(pqxx::transaction_base& t) override
     {

--- a/datastore/importers/nmdb-import-prowler/nmdb-import-prowler.cpp
+++ b/datastore/importers/nmdb-import-prowler/nmdb-import-prowler.cpp
@@ -24,7 +24,7 @@
 // Maintained by Sandia National Laboratories <Netmeld@sandia.gov>
 // =============================================================================
 
-#include <netmeld/datastore/tools/AbstractImportSpiritTool.hpp>
+#include <netmeld/datastore/tools/AbstractImportTool.hpp>
 #include <netmeld/datastore/parsers/ParserHelper.hpp> // if parser not needed
 
 #include "Parser.hpp"
@@ -37,7 +37,7 @@ namespace nmdt = netmeld::datastore::tools;
 // Import tool definition
 // =============================================================================
 template<typename P, typename R>
-class Tool : public nmdt::AbstractImportSpiritTool<P,R>
+class Tool : public nmdt::AbstractImportTool<P,R>
 {
   // ===========================================================================
   // Variables
@@ -53,7 +53,7 @@ class Tool : public nmdt::AbstractImportSpiritTool<P,R>
   private: // Constructors should rarely appear at this scope
   protected: // Constructors intended for internal/subclass API
   public: // Constructors should generally be public
-    Tool() : nmdt::AbstractImportSpiritTool<P,R>
+    Tool() : nmdt::AbstractImportTool<P,R>
       (
        "prowler -M json",  // command line tool imports data from
        PROGRAM_NAME,       // program name (set in CMakeLists.txt)
@@ -66,7 +66,7 @@ class Tool : public nmdt::AbstractImportSpiritTool<P,R>
   // Methods
   // ===========================================================================
   private: // Methods part of internal API
-    // Overriden from AbstractImportSpiritTool
+    // Overriden from AbstractImportTool
     void
     addToolOptions() override
     {
@@ -97,7 +97,7 @@ class Tool : public nmdt::AbstractImportSpiritTool<P,R>
       this->executionStop = nmco::Time();
     }
 
-    // Overriden from AbstractImportSpiritTool
+    // Overriden from AbstractImportTool
     void
     specificInserts(pqxx::transaction_base& t) override
     {

--- a/datastore/importers/nmdb-import-rpm-query/nmdb-import-rpm-query.cpp
+++ b/datastore/importers/nmdb-import-rpm-query/nmdb-import-rpm-query.cpp
@@ -24,7 +24,7 @@
 // Maintained by Sandia National Laboratories <Netmeld@sandia.gov>
 // =============================================================================
 
-#include <netmeld/datastore/tools/AbstractImportTool.hpp>
+#include <netmeld/datastore/tools/AbstractImportSpiritTool.hpp>
 #include "Parser.hpp"
 
 namespace nmdt = netmeld::datastore::tools;
@@ -33,7 +33,7 @@ namespace nmdt = netmeld::datastore::tools;
 // Import tool definition
 // =============================================================================
 template<typename P, typename R>
-class Tool : public nmdt::AbstractImportTool<P,R>
+class Tool : public nmdt::AbstractImportSpiritTool<P,R>
 {
   // ===========================================================================
   // Variables
@@ -48,7 +48,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
   private:
   protected:
   public:
-    Tool() : nmdt::AbstractImportTool<P,R>
+    Tool() : nmdt::AbstractImportSpiritTool<P,R>
       (
        R"(rpm -qa --queryformat="%-50{NAME}%10{VERSION}-%-20{RELEASE}%-20{ARCH}%{SUMMARY}\n")",  // command line tool imports data from
        PROGRAM_NAME,           // program name (set in CMakeLists.txt)

--- a/datastore/importers/nmdb-import-show-cdp-neighbor/nmdb-import-show-cdp-neighbor.cpp
+++ b/datastore/importers/nmdb-import-show-cdp-neighbor/nmdb-import-show-cdp-neighbor.cpp
@@ -24,7 +24,7 @@
 // Maintained by Sandia National Laboratories <Netmeld@sandia.gov>
 // =============================================================================
 
-#include <netmeld/datastore/tools/AbstractImportTool.hpp>
+#include <netmeld/datastore/tools/AbstractImportSpiritTool.hpp>
 
 #include "Parser.hpp"
 
@@ -32,10 +32,10 @@ namespace nmdt = netmeld::datastore::tools;
 
 
 template<typename P, typename R>
-class Tool : public nmdt::AbstractImportTool<P,R>
+class Tool : public nmdt::AbstractImportSpiritTool<P,R>
 {
   public:
-    Tool() : nmdt::AbstractImportTool<P,R>
+    Tool() : nmdt::AbstractImportSpiritTool<P,R>
       ("show cdp neighbor detail", PROGRAM_NAME, PROGRAM_VERSION)
     {}
 

--- a/datastore/importers/nmdb-import-show-inventory/nmdb-import-show-inventory.cpp
+++ b/datastore/importers/nmdb-import-show-inventory/nmdb-import-show-inventory.cpp
@@ -27,7 +27,7 @@
 #include <regex>
 
 #include <netmeld/datastore/objects/DeviceInformation.hpp>
-#include <netmeld/datastore/tools/AbstractImportTool.hpp>
+#include <netmeld/datastore/tools/AbstractImportSpiritTool.hpp>
 
 namespace nmdo = netmeld::datastore::objects;
 namespace nmdp = netmeld::datastore::parsers;
@@ -88,10 +88,10 @@ class Parser :
 };
 
 template<typename P, typename R>
-class Tool : public nmdt::AbstractImportTool<P,R>
+class Tool : public nmdt::AbstractImportSpiritTool<P,R>
 {
   public:
-    Tool() : nmdt::AbstractImportTool<P,R>
+    Tool() : nmdt::AbstractImportSpiritTool<P,R>
       ("show inventory", PROGRAM_NAME, PROGRAM_VERSION)
     {}
 

--- a/datastore/importers/nmdb-import-show-mac-address-table/nmdb-import-show-mac-address-table.cpp
+++ b/datastore/importers/nmdb-import-show-mac-address-table/nmdb-import-show-mac-address-table.cpp
@@ -25,7 +25,7 @@
 // =============================================================================
 
 #include <netmeld/core/utils/StringUtilities.hpp>
-#include <netmeld/datastore/tools/AbstractImportTool.hpp>
+#include <netmeld/datastore/tools/AbstractImportSpiritTool.hpp>
 #include <boost/algorithm/string.hpp>
 
 #include "Parser.hpp"
@@ -35,7 +35,7 @@ namespace nmdt = netmeld::datastore::tools;
 
 
 template<typename P, typename R>
-class Tool : public nmdt::AbstractImportTool<P,R>
+class Tool : public nmdt::AbstractImportSpiritTool<P,R>
 {
   // ===========================================================================
   // Variables
@@ -51,7 +51,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
   private: // Constructors should rarely appear at this scope
   protected: // Constructors intended for internal/subclass API
   public: // Constructors should generally be public
-    Tool() : nmdt::AbstractImportTool<P,R>
+    Tool() : nmdt::AbstractImportSpiritTool<P,R>
       ("show mac address-table", PROGRAM_NAME, PROGRAM_VERSION)
     {}
 
@@ -60,7 +60,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
   // Methods
   // ===========================================================================
   private: // Methods part of internal API
-    // Overriden from AbstractImportTool
+    // Overriden from AbstractImportSpiritTool
     void
     specificInserts(pqxx::transaction_base& t) override
     {

--- a/datastore/importers/nmdb-import-show-neighbor/nmdb-import-show-neighbor.cpp
+++ b/datastore/importers/nmdb-import-show-neighbor/nmdb-import-show-neighbor.cpp
@@ -25,7 +25,7 @@
 // =============================================================================
 
 #include <netmeld/core/utils/StringUtilities.hpp>
-#include <netmeld/datastore/tools/AbstractImportTool.hpp>
+#include <netmeld/datastore/tools/AbstractImportSpiritTool.hpp>
 
 #include "Parser.hpp"
 
@@ -38,7 +38,7 @@ namespace nmdt = netmeld::datastore::tools;
 // Import tool definition
 // =============================================================================
 template<typename P, typename R>
-class Tool : public nmdt::AbstractImportTool<P,R>
+class Tool : public nmdt::AbstractImportSpiritTool<P,R>
 {
   // ===========================================================================
   // Variables
@@ -54,7 +54,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
   private: // Constructors should rarely appear at this scope
   protected: // Constructors intended for internal/subclass API
   public: // Constructors should generally be public
-    Tool() : nmdt::AbstractImportTool<P,R>
+    Tool() : nmdt::AbstractImportSpiritTool<P,R>
       (
        "(show arp) or (show ipv6 neighbors)",   // command line tool imports data from
        PROGRAM_NAME,           // program name (set in CMakeLists.txt)
@@ -67,7 +67,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
   // Methods
   // ===========================================================================
   private: // Methods part of internal API
-    // Overriden from AbstractImportTool
+    // Overriden from AbstractImportSpiritTool
     void
     specificInserts(pqxx::transaction_base& t) override
     {

--- a/datastore/importers/nmdb-import-traceroute/nmdb-import-traceroute.cpp
+++ b/datastore/importers/nmdb-import-traceroute/nmdb-import-traceroute.cpp
@@ -24,7 +24,7 @@
 // Maintained by Sandia National Laboratories <Netmeld@sandia.gov>
 // =============================================================================
 
-#include <netmeld/datastore/tools/AbstractImportTool.hpp>
+#include <netmeld/datastore/tools/AbstractImportSpiritTool.hpp>
 
 #include "Parser.hpp"
 
@@ -37,7 +37,7 @@ namespace nmdt = netmeld::datastore::tools;
 // Import tool definition
 // =============================================================================
 template<typename P, typename R>
-class Tool : public nmdt::AbstractImportTool<P,R>
+class Tool : public nmdt::AbstractImportSpiritTool<P,R>
 {
   // ===========================================================================
   // Variables
@@ -49,7 +49,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
       // std::string            programName;
       // std::string            version;
       // ProgramOptions         opts;
-    // Inhertied from AbstractImportTool at this scope
+    // Inhertied from AbstractImportSpiritTool at this scope
       // TResults                 tResults;
       // nmco::Uuid               toolRunId;
       // nmco::Time               executionStart;
@@ -64,7 +64,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
   private: // Constructors should rarely appear at this scope
   protected: // Constructors intended for internal/subclass API
   public: // Constructors should generally be public
-    Tool() : nmdt::AbstractImportTool<P,R>
+    Tool() : nmdt::AbstractImportSpiritTool<P,R>
       (
        "traceroute [-n] | tracert [-d]",  // command line tool imports data from
        PROGRAM_NAME,           // program name (set in CMakeLists.txt)
@@ -78,7 +78,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
   // ===========================================================================
   private: // Methods part of internal API
 
-    // Overriden from AbstractImportTool
+    // Overriden from AbstractImportSpiritTool
     void
     specificInserts(pqxx::transaction_base& t) override
     {
@@ -97,7 +97,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
     // Inherited from AbstractTool at this scope
       // std::string const getDbName() const;
       // virtual void printVersion() const;
-    // Inherited from AbstractImportTool at this scope
+    // Inherited from AbstractImportSpiritTool at this scope
       // fs::path    const getDataPath() const;
       // std::string const getDeviceId() const;
       // nmco::Uuid   const getToolRunId() const;

--- a/datastore/importers/nmdb-import-tshark/nmdb-import-tshark.cpp
+++ b/datastore/importers/nmdb-import-tshark/nmdb-import-tshark.cpp
@@ -28,7 +28,7 @@
 #include <future>
 
 #include <netmeld/datastore/objects/DeviceInformation.hpp>
-#include <netmeld/datastore/tools/AbstractImportTool.hpp>
+#include <netmeld/datastore/tools/AbstractImportSpiritTool.hpp>
 #include <netmeld/datastore/parsers/ParserHelper.hpp>
 
 #include "Parser.hpp"
@@ -47,7 +47,7 @@ void sigIntHandler(int) { std::signal(SIGINT, SIG_DFL); }
 // Import tool definition
 // =============================================================================
 template<typename P, typename R>
-class Tool : public nmdt::AbstractImportTool<P,R>
+class Tool : public nmdt::AbstractImportSpiritTool<P,R>
 {
   // ===========================================================================
   // Variables
@@ -65,7 +65,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
   private: // Constructors should rarely appear at this scope
   protected: // Constructors intended for internal/subclass API
   public: // Constructors should generally be public
-    Tool() : nmdt::AbstractImportTool<P,R>
+    Tool() : nmdt::AbstractImportSpiritTool<P,R>
       (
        "tshark -V -T json",  // command line tool imports data from
        PROGRAM_NAME,         // program name (set in CMakeLists.txt)
@@ -78,7 +78,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
   // Methods
   // ===========================================================================
   private: // Methods part of internal API
-    // Overriden from AbstractImportTool
+    // Overriden from AbstractImportSpiritTool
     void
     addToolOptions() override
     {
@@ -112,7 +112,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
           );
     }
 
-    // Overriden from AbstractImportTool
+    // Overriden from AbstractImportSpiritTool
     void
     parseData() override
     {
@@ -145,7 +145,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
       this->executionStop = nmco::Time();
     }
 
-    // Overriden from AbstractImportTool
+    // Overriden from AbstractImportSpiritTool
     void
     specificInserts(pqxx::transaction_base& t) override
     {

--- a/datastore/importers/nmdb-import-vyos/nmdb-import-vyos.cpp
+++ b/datastore/importers/nmdb-import-vyos/nmdb-import-vyos.cpp
@@ -24,7 +24,7 @@
 // Maintained by Sandia National Laboratories <Netmeld@sandia.gov>
 // =============================================================================
 
-#include <netmeld/datastore/tools/AbstractImportTool.hpp>
+#include <netmeld/datastore/tools/AbstractImportSpiritTool.hpp>
 
 #include "Parser.hpp"
 
@@ -36,7 +36,7 @@ namespace nmdt = netmeld::datastore::tools;
 // Import tool definition
 // =============================================================================
 template<typename P, typename R>
-class Tool : public nmdt::AbstractImportTool<P,R>
+class Tool : public nmdt::AbstractImportSpiritTool<P,R>
 {
   // ===========================================================================
   // Variables
@@ -52,7 +52,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
   private: // Constructors should rarely appear at this scope
   protected: // Constructors intended for internal/subclass API
   public: // Constructors should generally be public
-    Tool() : nmdt::AbstractImportTool<P,R>
+    Tool() : nmdt::AbstractImportSpiritTool<P,R>
       (
        "show configuration",   // command line tool imports data from
        PROGRAM_NAME,           // program name (set in CMakeLists.txt)
@@ -65,7 +65,7 @@ class Tool : public nmdt::AbstractImportTool<P,R>
   // Methods
   // ===========================================================================
   private: // Methods part of internal API
-    // Overriden from AbstractImportTool
+    // Overriden from AbstractImportSpiritTool
     void
     specificInserts(pqxx::transaction_base& t) override
     {


### PR DESCRIPTION
- Created AbstractImportTool base class
- Created import tool subclasses for Spirit (AbstractImportSpiritTool), Json (AbstractImportJsonTool), and Xml (AbstractImportXmlTool)
- Modified all importers to use the new subclasses