### PR TITLE
added check for root user

### DIFF
--- a/fetchers/nm-fetch-ansible/ansible-playbooks/ansible.cfg
+++ b/fetchers/nm-fetch-ansible/ansible-playbooks/ansible.cfg
@@ -5,6 +5,12 @@ nocolor: True
 #remote_tmp: /tmp/.ansible/tmp
 #enable_task_debugger: True
 
+# Uncomment 'remote_user' and 'private_key_file' to set the default remote user as "root"
+# using the key specified in 'private_key_file'. This will automatically trigger privileged command
+# collect without requiring a password.
+#remote_user: root
+#private_key_file: /path/to/key
+
 # Uncomment 'host_key_checking' to avoid errors when SSH'ing without keys for
 # the first time
 #host_key_checking: false

--- a/fetchers/nm-fetch-ansible/ansible-playbooks/roles/enable-privilleged-commands/tasks/main.yaml
+++ b/fetchers/nm-fetch-ansible/ansible-playbooks/roles/enable-privilleged-commands/tasks/main.yaml
@@ -4,7 +4,7 @@
     cmd_list: "{{ cmd_list + [ item | combine({'become':'yes'}) ] }}"
   register:
   loop: "{{ pcmd_list | flatten(1) }}"
-  when: lookup('config', 'DEFAULT_BECOME_ASK_PASS')
+  when: "(lookup('config', 'DEFAULT_REMOTE_USER') == 'root') or lookup('config', 'DEFAULT_BECOME_ASK_PASS')"
 
 #- name: "Debugging data collection values"
 #  debug:


### PR DESCRIPTION
Ansible will now automatically gather privileged commands when the user is root without requiring password when default.remote_user is root and using SSH keys.