### PR TITLE
Prowler v3 mods

### DIFF
--- a/core/common/objects/DnsQuestion.cpp
+++ b/core/common/objects/DnsQuestion.cpp
@@ -94,7 +94,7 @@ namespace netmeld::core::objects {
     oss << "["
         << "questionFqdn: " << questionFqdn << ", "
         << "questionClass: " << questionClass << ", "
-        << "questionType: " << questionType 
+        << "questionType: " << questionType
         << "]";
 
     return oss.str();

--- a/core/common/objects/DnsResponse.cpp
+++ b/core/common/objects/DnsResponse.cpp
@@ -137,7 +137,7 @@ namespace netmeld::core::objects {
         << "responseClass: " << responseClass << ", "
         << "responseType: " << responseType << ", "
         << "responseTtl: " << responseTtl << ", "
-        << "responseData: " << responseData 
+        << "responseData: " << responseData
         << "]";
 
     return oss.str();

--- a/core/common/utils/CMakeLists.txt
+++ b/core/common/utils/CMakeLists.txt
@@ -1,5 +1,5 @@
 # =============================================================================
-# Copyright 2017 National Technology & Engineering Solutions of Sandia, LLC
+# Copyright 2023 National Technology & Engineering Solutions of Sandia, LLC
 # (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
 # Government retains certain rights in this software.
 #
@@ -24,3 +24,12 @@
 # Maintained by Sandia National Laboratories <Netmeld@sandia.gov>
 # =============================================================================
 
+
+foreach(ITEM
+    StringUtilities
+  )
+  nm_add_test(${ITEM})
+  target_link_libraries(${TGT_TEST}
+      netmeld-core
+    )
+endforeach()

--- a/core/common/utils/StringUtilities.cpp
+++ b/core/common/utils/StringUtilities.cpp
@@ -1,5 +1,5 @@
 // =============================================================================
-// Copyright 2017 National Technology & Engineering Solutions of Sandia, LLC
+// Copyright 2023 National Technology & Engineering Solutions of Sandia, LLC
 // (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
 // Government retains certain rights in this software.
 //
@@ -25,8 +25,6 @@
 // =============================================================================
 
 #include <algorithm>
-#include <sstream>
-#include <boost/algorithm/string.hpp>
 
 #include <netmeld/core/utils/StringUtilities.hpp>
 
@@ -49,63 +47,6 @@ namespace netmeld::core::utils {
     std::transform(text.begin(), text.end(), text.begin(),
         [](unsigned char c){ return std::toupper(c); });
     return text;
-  }
-
-  std::string
-  toString(const std::set<std::string>& con, const char sep)
-  {
-    std::ostringstream oss;
-    if (!con.empty()) {
-      auto iter {con.begin()};
-      oss << *iter;
-      ++iter;
-      for (; iter != con.end(); ++iter) {
-        oss << sep << *iter;
-      }
-    }
-    return oss.str();
-  }
-  std::string
-  toString(const std::vector<std::string>& con, const char sep)
-  {
-    std::ostringstream oss;
-    if (!con.empty()) {
-      auto iter {con.begin()};
-      oss << *iter;
-      ++iter;
-      for (; iter != con.end(); ++iter) {
-        oss << sep << *iter;
-      }
-    }
-    return oss.str();
-  }
-  std::string
-  toString(const std::set<std::string>& con, const std::string sep)
-  {
-    std::ostringstream oss;
-    if (!con.empty()) {
-      auto iter {con.begin()};
-      oss << *iter;
-      ++iter;
-      for (; iter != con.end(); ++iter) {
-        oss << sep << *iter;
-      }
-    }
-    return oss.str();
-  }
-  std::string
-  toString(const std::vector<std::string>& con, const std::string sep)
-  {
-    std::ostringstream oss;
-    if (!con.empty()) {
-      auto iter {con.begin()};
-      oss << *iter;
-      ++iter;
-      for (; iter != con.end(); ++iter) {
-        oss << sep << *iter;
-      }
-    }
-    return oss.str();
   }
 
   std::string
@@ -147,7 +88,7 @@ namespace netmeld::core::utils {
     // the interface names obtained from the running configuration.
     std::string ifaceName{toLower(_ifaceName)};
 
-    boost::trim(ifaceName);
+    trim(ifaceName);
 
     // Ethernet variations (ordered by speed)
     if (ifaceName.starts_with("et") &&

--- a/core/common/utils/StringUtilities.cpp
+++ b/core/common/utils/StringUtilities.cpp
@@ -79,6 +79,34 @@ namespace netmeld::core::utils {
     }
     return oss.str();
   }
+  std::string
+  toString(const std::set<std::string>& con, const std::string sep)
+  {
+    std::ostringstream oss;
+    if (!con.empty()) {
+      auto iter {con.begin()};
+      oss << *iter;
+      ++iter;
+      for (; iter != con.end(); ++iter) {
+        oss << sep << *iter;
+      }
+    }
+    return oss.str();
+  }
+  std::string
+  toString(const std::vector<std::string>& con, const std::string sep)
+  {
+    std::ostringstream oss;
+    if (!con.empty()) {
+      auto iter {con.begin()};
+      oss << *iter;
+      ++iter;
+      for (; iter != con.end(); ++iter) {
+        oss << sep << *iter;
+      }
+    }
+    return oss.str();
+  }
 
   std::string
   trim(const std::string& orig)

--- a/core/common/utils/StringUtilities.hpp
+++ b/core/common/utils/StringUtilities.hpp
@@ -40,6 +40,8 @@ namespace netmeld::core::utils {
 
   std::string toString(const std::set<std::string>&, const char sep=' ');
   std::string toString(const std::vector<std::string>&, const char sep=' ');
+  std::string toString(const std::set<std::string>&, const std::string sep);
+  std::string toString(const std::vector<std::string>&, const std::string sep);
 
   std::string getSrvcString(const std::string&,
                             const std::string&, const std::string&);

--- a/core/common/utils/StringUtilities.hpp
+++ b/core/common/utils/StringUtilities.hpp
@@ -1,5 +1,5 @@
 // =============================================================================
-// Copyright 2017 National Technology & Engineering Solutions of Sandia, LLC
+// Copyright 2023 National Technology & Engineering Solutions of Sandia, LLC
 // (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
 // Government retains certain rights in this software.
 //
@@ -28,6 +28,7 @@
 #define STRING_UTILITIES_HPP
 
 #include <set>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -38,14 +39,41 @@ namespace netmeld::core::utils {
   std::string toUpper(const std::string&);
   std::string trim(const std::string&);
 
-  std::string toString(const std::set<std::string>&, const char sep=' ');
-  std::string toString(const std::vector<std::string>&, const char sep=' ');
-  std::string toString(const std::set<std::string>&, const std::string sep);
-  std::string toString(const std::vector<std::string>&, const std::string sep);
-
   std::string getSrvcString(const std::string&,
                             const std::string&, const std::string&);
 
   std::string expandCiscoIfaceName(const std::string&);
+
+  // ==========================================================================
+  // toString()
+  template<typename Iterator>
+  std::string
+  toString(Iterator begin, Iterator end, const std::string& sep)
+  {
+    std::ostringstream oss;
+    if (begin != end) {
+      oss << *begin;
+      ++begin;
+      for (; begin != end; ++begin) {
+        oss << sep << *begin;
+      }
+    }
+
+    return oss.str();
+  }
+  template<typename SequenceContainer>
+  std::string
+  toString(const SequenceContainer& con, const char sep=' ')
+  {
+    const std::string sSep {sep};
+    return toString(con.begin(), con.end(), sSep);
+  }
+  template<typename SequenceContainer>
+  std::string
+  toString(const SequenceContainer& con, const std::string& sep)
+  {
+    return toString(con.begin(), con.end(), sep);
+  }
+  // ==========================================================================
 }
 #endif  /* STRING_UTILITIES_HPP */

--- a/core/common/utils/StringUtilities.test.cpp
+++ b/core/common/utils/StringUtilities.test.cpp
@@ -1,0 +1,106 @@
+// =============================================================================
+// Copyright 2023 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// =============================================================================
+// Maintained by Sandia National Laboratories <Netmeld@sandia.gov>
+// =============================================================================
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MAIN
+#include <boost/test/unit_test.hpp>
+
+#include <netmeld/core/utils/StringUtilities.hpp>
+
+namespace nmcu = netmeld::core::utils;
+
+BOOST_AUTO_TEST_CASE(testToLower)
+{
+  std::map<std::string, std::string> tests {
+      {"A", "a"}
+    , {"Abc", "abc"}
+    , {"AbC", "abc"}
+    , {"123", "123"}
+    , {" aBc DeF ", " abc def "}
+    , {"", ""}
+    };
+
+  for (const auto& [key, value] : tests) {
+    BOOST_TEST(value == nmcu::toLower(key));
+  }
+}
+
+BOOST_AUTO_TEST_CASE(testToUpper)
+{
+  std::map<std::string, std::string> tests {
+      {"A", "A"}
+    , {"Abc", "ABC"}
+    , {"AbC", "ABC"}
+    , {"123", "123"}
+    , {" aBc DeF ", " ABC DEF "}
+    , {"", ""}
+    };
+
+  for (const auto& [key, value] : tests) {
+    BOOST_TEST(value == nmcu::toUpper(key));
+  }
+}
+
+BOOST_AUTO_TEST_CASE(testTrim)
+{
+  std::map<std::string, std::string> tests {
+      {"a", "a"}
+    , {" B ", "B"}
+    , {" c", "c"}
+    , {"D ", "D"}
+    , {"  e     ", "e"}
+    , {" aBc DeF ", "aBc DeF"}
+    , {"       ", ""}
+    };
+
+  for (const auto& [key, value] : tests) {
+    BOOST_TEST(value == nmcu::trim(key));
+  }
+}
+
+BOOST_AUTO_TEST_CASE(testToString)
+{
+  {
+    std::set<std::string> test {"a", "b", "c"};
+
+    BOOST_TEST("a b c" == nmcu::toString(test));
+    BOOST_TEST("a,b,c" == nmcu::toString(test, ','));
+    BOOST_TEST("a, b, c" == nmcu::toString(test, ", "));
+  }
+  {
+    std::vector<std::string> test {"a", "b", "c"};
+
+    BOOST_TEST("a b c" == nmcu::toString(test));
+    BOOST_TEST("a,b,c" == nmcu::toString(test, ','));
+    BOOST_TEST("a, b, c" == nmcu::toString(test, ", "));
+  }
+}
+
+BOOST_AUTO_TEST_CASE(testGetSrvcString)
+{
+  BOOST_TEST("a:b:c" == nmcu::getSrvcString("a", "b", "c"));
+  BOOST_TEST("1:2:3" == nmcu::getSrvcString("1", "2", "3"));
+}

--- a/datalake/common/handlers/Git.cpp
+++ b/datalake/common/handlers/Git.cpp
@@ -68,7 +68,7 @@ namespace netmeld::datalake::handlers {
     std::ostringstream oss;
     std::string branch{this->branchName};
     if (this->branchName.empty()) {
-    
+
       oss << "git branch --show-current";
       branch = {nmcu::trim(nmcu::cmdExecOut(oss.str()))};
       oss.str("");

--- a/datalake/common/handlers/Git.hpp
+++ b/datalake/common/handlers/Git.hpp
@@ -43,7 +43,7 @@ namespace netmeld::datalake::handlers {
       const std::string  CHECK_IN_PREFIX     {"check-in:"};
       const std::string  INGEST_TOOL_PREFIX  {"ingest-tool:"};
       const std::string  TOOL_ARGS_PREFIX    {"tool-args:"};
-      
+
       std::string branchName;
 
       nmcu::FileManager& nmfm {nmcu::FileManager::getInstance()};

--- a/datastore/common/objects/DnsResolver.cpp
+++ b/datastore/common/objects/DnsResolver.cpp
@@ -102,7 +102,7 @@ namespace netmeld::datastore::objects {
         << "scopeDomain: " << scopeDomain  << ", "
         << "srcIpAddr: " << srcIpAddr  << ", "
         << "dstIpAddr: " << dstIpAddr  << ", "
-        << "dstPort: " << dstPort 
+        << "dstPort: " << dstPort
         << "]"; // closing bracket
 
     return oss.str();

--- a/datastore/common/objects/InterfaceNetwork.cpp
+++ b/datastore/common/objects/InterfaceNetwork.cpp
@@ -328,8 +328,8 @@ namespace netmeld::datastore::objects {
     oss << "name: " << name << ", "
         << "description: " << description << ", "
         << "mediaType: " << mediaType << ", "
-        << "mode: " << mode << ", " 
-        << "State:" << std::boolalpha << isUp << ", " 
+        << "mode: " << mode << ", "
+        << "State:" << std::boolalpha << isUp << ", "
         << "DiscProtoEnabled: " << isDiscoveryProtocolEnabled << ", "
         << "macAddr: " << macAddr .toDebugString() << ", "
         ;
@@ -337,7 +337,7 @@ namespace netmeld::datastore::objects {
     oss << "Port-Security: ["
         << "State: " << isPortSecurityEnabled << ", "
         << "portSecurityMaxMacAddrs: " << portSecurityMaxMacAddrs  << ", "
-        << "portSecurityViolationAction: " << portSecurityViolationAction  << ", " 
+        << "portSecurityViolationAction: " << portSecurityViolationAction  << ", "
         << "Sticky :" << isPortSecurityStickyMac << "], "
         ;
 

--- a/datastore/common/objects/Service.cpp
+++ b/datastore/common/objects/Service.cpp
@@ -233,7 +233,7 @@ namespace netmeld::datastore::objects {
         << "serviceReason: " << serviceReason  << ", "
         << "protocol: " << protocol  << ", "
         << "dstPorts: " << dstPorts  << ", "
-        << "srcPorts: " << srcPorts 
+        << "srcPorts: " << srcPorts
         // End of formatting
         << "]";
 

--- a/datastore/common/objects/TracerouteHop.cpp
+++ b/datastore/common/objects/TracerouteHop.cpp
@@ -83,7 +83,7 @@ namespace netmeld::datastore::objects {
     oss << "["
         << "hopIpAddr: " << hopIpAddr  << ", "
         << "dstIpAddr: " << dstIpAddr  << ", "
-        << "hopCount: " << hopCount 
+        << "hopCount: " << hopCount
         << "]";
 
     return oss.str();

--- a/datastore/common/objects/Vlan.cpp
+++ b/datastore/common/objects/Vlan.cpp
@@ -128,7 +128,7 @@ namespace netmeld::datastore::objects {
     oss << "[" // opening bracket
         << "vlanId: " << vlanId  << ", "
         << "ipNet: " << ipNet  << ", "
-        << "description: " << description 
+        << "description: " << description
         << "]"; // closing bracket
 
     return oss.str();

--- a/datastore/common/objects/Vrf.cpp
+++ b/datastore/common/objects/Vrf.cpp
@@ -115,7 +115,7 @@ namespace netmeld::datastore::objects {
   Vrf::toDebugString() const
   {
     std::ostringstream oss;
-    
+
     oss << "[" // opening bracket
         << "vrfId: " << vrfId << ", "
         << "ifaces: " << ifaces << ", "

--- a/datastore/common/objects/aws/Attachment.cpp
+++ b/datastore/common/objects/aws/Attachment.cpp
@@ -85,8 +85,8 @@ namespace netmeld::datastore::objects::aws {
     std::ostringstream oss;
 
     oss << '['
-        << "attachmentId: " << attachmentId << ", " 
-        << "status: " << status << ", " 
+        << "attachmentId: " << attachmentId << ", "
+        << "status: " << status << ", "
         << "deleteOnTermination: " << deleteOnTermination
         << ']'
         ;

--- a/datastore/common/schemas/000custom-types-create.sql
+++ b/datastore/common/schemas/000custom-types-create.sql
@@ -98,11 +98,11 @@ CREATE TYPE RouteHop AS (
 -- Prowler severity enum to aid in sorting.
 -- ----------------------------------------------------------------------
 CREATE TYPE ProwlerSeverity AS ENUM (
-    'Critical'
-  , 'High'
-  , 'Medium'
-  , 'Low'
-  , 'Informational'
+    'critical'
+  , 'high'
+  , 'medium'
+  , 'low'
+  , 'informational'
 );
 
 -- ----------------------------------------------------------------------

--- a/datastore/common/schemas/001custom-functions-create.sql
+++ b/datastore/common/schemas/001custom-functions-create.sql
@@ -77,12 +77,12 @@ DECLARE
   val TEXT;
 BEGIN
   CASE severity
-  WHEN 'Critical'       THEN val='Critical';
-  WHEN 'High'           THEN val='High';
-  WHEN 'Medium'         THEN val='Medium';
-  WHEN 'Low'            THEN val='Low';
-  WHEN 'Informational'  THEN val='Informational';
-  ELSE                       val='Undefined';
+  WHEN 'critical'       THEN val='critical';
+  WHEN 'high'           THEN val='high';
+  WHEN 'medium'         THEN val='medium';
+  WHEN 'low'            THEN val='low';
+  WHEN 'informational'  THEN val='informational';
+  ELSE                       val='undefined';
   END CASE;
   RETURN val;
 END;

--- a/datastore/common/schemas/012tool-results-tables-create.sql
+++ b/datastore/common/schemas/012tool-results-tables-create.sql
@@ -867,7 +867,7 @@ ON raw_tool_observations(observation);
 
 -- ----------------------------------------------------------------------
 
-CREATE TABLE raw_prowler_checks (
+CREATE TABLE raw_prowler_v2_checks (
       tool_run_id                 UUID            NOT NULL
     , account_number              TEXT            NULL
     , timestamp                   TIMESTAMP       NULL
@@ -891,8 +891,8 @@ CREATE TABLE raw_prowler_checks (
 -- Since this table lacks a PRIMARY KEY and allows NULLs (>2):
 -- Create UNIQUE expressional index with substitutions of NULL values
 -- for use with `ON CONFLICT` guards against duplicate data.
-CREATE UNIQUE INDEX raw_prowler_checks_idx_unique
-ON raw_prowler_checks(
+CREATE UNIQUE INDEX raw_prowler_v2_checks_idx_unique
+ON raw_prowler_v2_checks(
   HASH_CHAIN( tool_run_id::TEXT, account_number, AS_TEXT(timestamp)
             , region, level, control_id, service, status, AS_TEXT(severity)
             , control, risk, remediation, documentation_link, resource_id
@@ -900,47 +900,195 @@ ON raw_prowler_checks(
 );
 
 -- Partial indexes
-CREATE INDEX raw_prowler_checks_idx_tool_run_id
-ON raw_prowler_checks(tool_run_id);
+CREATE INDEX raw_prowler_v2_checks_idx_tool_run_id
+ON raw_prowler_v2_checks(tool_run_id);
 
-CREATE INDEX raw_prowler_checks_idx_account_number
-ON raw_prowler_checks(account_number);
+CREATE INDEX raw_prowler_v2_checks_idx_account_number
+ON raw_prowler_v2_checks(account_number);
 
-CREATE INDEX raw_prowler_checks_idx_timestamp
-ON raw_prowler_checks(timestamp);
+CREATE INDEX raw_prowler_v2_checks_idx_timestamp
+ON raw_prowler_v2_checks(timestamp);
 
-CREATE INDEX raw_prowler_checks_idx_region
-ON raw_prowler_checks(region);
+CREATE INDEX raw_prowler_v2_checks_idx_region
+ON raw_prowler_v2_checks(region);
 
-CREATE INDEX raw_prowler_checks_idx_level
-ON raw_prowler_checks(level);
+CREATE INDEX raw_prowler_v2_checks_idx_level
+ON raw_prowler_v2_checks(level);
 
-CREATE INDEX raw_prowler_checks_idx_control_id
-ON raw_prowler_checks(control_id);
+CREATE INDEX raw_prowler_v2_checks_idx_control_id
+ON raw_prowler_v2_checks(control_id);
 
-CREATE INDEX raw_prowler_checks_idx_service
-ON raw_prowler_checks(service);
+CREATE INDEX raw_prowler_v2_checks_idx_service
+ON raw_prowler_v2_checks(service);
 
-CREATE INDEX raw_prowler_checks_idx_status
-ON raw_prowler_checks(status);
+CREATE INDEX raw_prowler_v2_checks_idx_status
+ON raw_prowler_v2_checks(status);
 
-CREATE INDEX raw_prowler_checks_idx_severity
-ON raw_prowler_checks(severity);
+CREATE INDEX raw_prowler_v2_checks_idx_severity
+ON raw_prowler_v2_checks(severity);
 
-CREATE INDEX raw_prowler_checks_idx_control
-ON raw_prowler_checks(control);
+CREATE INDEX raw_prowler_v2_checks_idx_control
+ON raw_prowler_v2_checks(control);
 
-CREATE INDEX raw_prowler_checks_idx_risk
-ON raw_prowler_checks(risk);
+CREATE INDEX raw_prowler_v2_checks_idx_risk
+ON raw_prowler_v2_checks(risk);
 
-CREATE INDEX raw_prowler_checks_idx_remediation
-ON raw_prowler_checks(remediation);
+CREATE INDEX raw_prowler_v2_checks_idx_remediation
+ON raw_prowler_v2_checks(remediation);
 
-CREATE INDEX raw_prowler_checks_idx_documentation_link
-ON raw_prowler_checks(documentation_link);
+CREATE INDEX raw_prowler_v2_checks_idx_documentation_link
+ON raw_prowler_v2_checks(documentation_link);
 
-CREATE INDEX raw_prowler_checks_idx_resource_id
-ON raw_prowler_checks(resource_id);
+CREATE INDEX raw_prowler_v2_checks_idx_resource_id
+ON raw_prowler_v2_checks(resource_id);
+
+
+-- ----------------------------------------------------------------------
+
+CREATE TABLE raw_prowler_v3_checks (
+      tool_run_id                 UUID            NOT NULL
+    , assessment_start_time       TIMESTAMP       NOT NULL
+    , finding_unique_id           TEXT            NOT NULL
+    , provider                    TEXT            NOT NULL
+    , profile                     TEXT            NOT NULL
+    , account_id                  TEXT            NOT NULL
+    , organizations_info          TEXT            NULL
+    , region                      TEXT            NOT NULL
+    , check_id                    TEXT            NOT NULL
+    , check_title                 TEXT            NOT NULL
+    , check_types                 TEXT            NULL
+    , service_name                TEXT            NOT NULL
+    , sub_service_name            TEXT            NULL
+    , status                      TEXT            NOT NULL
+    , status_extended             TEXT            NOT NULL
+    , severity                    ProwlerSeverity NOT NULL
+    , resource_id                 TEXT            NOT NULL
+    , resource_arn                TEXT            NULL
+    , resource_tags               TEXT            NULL
+    , resource_type               TEXT            NOT NULL
+    , resource_details            TEXT            NULL
+    , description                 TEXT            NOT NULL
+    , risk                        TEXT            NULL
+    , related_url                 TEXT            NULL
+    , recommendation              TEXT            NOT NULL
+    , recommendation_url          TEXT            NOT NULL
+    , remediation_code            TEXT            NULL
+    , categories                  TEXT            NULL
+    , notes                       TEXT            NULL
+    , compliance                  TEXT            NULL
+    , FOREIGN KEY (tool_run_id)
+        REFERENCES tool_runs(id)
+        ON DELETE CASCADE
+        ON UPDATE CASCADE
+);
+
+-- Since this table lacks a PRIMARY KEY and allows NULLs (>2):
+-- Create UNIQUE expressional index with substitutions of NULL values
+-- for use with `ON CONFLICT` guards against duplicate data.
+CREATE UNIQUE INDEX raw_prowler_v3_checks_idx_unique
+ON raw_prowler_v3_checks(
+  HASH_CHAIN( tool_run_id::TEXT, AS_TEXT(assessment_start_time)
+            , finding_unique_id, provider, profile, account_id
+            , organizations_info, region, check_id, check_title
+            , check_types, service_name, sub_service_name, status
+            , status_extended, AS_TEXT(severity), resource_id
+            , resource_arn, resource_tags, resource_type
+            , resource_details, description, risk, related_url
+            , recommendation, recommendation_url, remediation_code
+            , categories, notes, compliance
+            )
+);
+
+-- Partial indexes
+CREATE INDEX raw_prowler_v3_checks_idx_tool_run_id
+ON raw_prowler_v3_checks(tool_run_id);
+
+CREATE INDEX raw_prowler_v3_checks_idx_assessment_start_time
+ON raw_prowler_v3_checks(assessment_start_time);
+
+CREATE INDEX raw_prowler_v3_checks_idx_finding_unique_id
+ON raw_prowler_v3_checks(finding_unique_id);
+
+CREATE INDEX raw_prowler_v3_checks_idx_provider
+ON raw_prowler_v3_checks(provider);
+
+CREATE INDEX raw_prowler_v3_checks_idx_profile
+ON raw_prowler_v3_checks(profile);
+
+CREATE INDEX raw_prowler_v3_checks_idx_account_id
+ON raw_prowler_v3_checks(account_id);
+
+CREATE INDEX raw_prowler_v3_checks_idx_organizations_info
+ON raw_prowler_v3_checks(organizations_info);
+
+CREATE INDEX raw_prowler_v3_checks_idx_region
+ON raw_prowler_v3_checks(region);
+
+CREATE INDEX raw_prowler_v3_checks_idx_check_id
+ON raw_prowler_v3_checks(check_id);
+
+CREATE INDEX raw_prowler_v3_checks_idx_check_title
+ON raw_prowler_v3_checks(check_title);
+
+CREATE INDEX raw_prowler_v3_checks_idx_check_types
+ON raw_prowler_v3_checks(check_types);
+
+CREATE INDEX raw_prowler_v3_checks_idx_service_name
+ON raw_prowler_v3_checks(service_name);
+
+CREATE INDEX raw_prowler_v3_checks_idx_sub_service_name
+ON raw_prowler_v3_checks(sub_service_name);
+
+CREATE INDEX raw_prowler_v3_checks_idx_status
+ON raw_prowler_v3_checks(status);
+
+CREATE INDEX raw_prowler_v3_checks_idx_status_extended
+ON raw_prowler_v3_checks(status_extended);
+
+CREATE INDEX raw_prowler_v3_checks_idx_severity
+ON raw_prowler_v3_checks(severity);
+
+CREATE INDEX raw_prowler_v3_checks_idx_resource_id
+ON raw_prowler_v3_checks(resource_id);
+
+CREATE INDEX raw_prowler_v3_checks_idx_resource_arn
+ON raw_prowler_v3_checks(resource_arn);
+
+CREATE INDEX raw_prowler_v3_checks_idx_resource_tags
+ON raw_prowler_v3_checks(resource_tags);
+
+CREATE INDEX raw_prowler_v3_checks_idx_resource_type
+ON raw_prowler_v3_checks(resource_type);
+
+CREATE INDEX raw_prowler_v3_checks_idx_resource_details
+ON raw_prowler_v3_checks(resource_details);
+
+CREATE INDEX raw_prowler_v3_checks_idx_description
+ON raw_prowler_v3_checks(description);
+
+CREATE INDEX raw_prowler_v3_checks_idx_risk
+ON raw_prowler_v3_checks(risk);
+
+CREATE INDEX raw_prowler_v3_checks_idx_related_url
+ON raw_prowler_v3_checks(related_url);
+
+CREATE INDEX raw_prowler_v3_checks_idx_recommendation
+ON raw_prowler_v3_checks(recommendation);
+
+CREATE INDEX raw_prowler_v3_checks_idx_recommendation_url
+ON raw_prowler_v3_checks(recommendation_url);
+
+CREATE INDEX raw_prowler_v3_checks_idx_remediation_code
+ON raw_prowler_v3_checks(remediation_code);
+
+CREATE INDEX raw_prowler_v3_checks_idx_categories
+ON raw_prowler_v3_checks(categories);
+
+CREATE INDEX raw_prowler_v3_checks_idx_notes
+ON raw_prowler_v3_checks(notes);
+
+CREATE INDEX raw_prowler_v3_checks_idx_compliance
+ON raw_prowler_v3_checks(compliance);
 
 
 -- ----------------------------------------------------------------------

--- a/datastore/common/schemas/022tool-results-views-create.sql
+++ b/datastore/common/schemas/022tool-results-views-create.sql
@@ -1,5 +1,5 @@
 -- =============================================================================
--- Copyright 2017 National Technology & Engineering Solutions of Sandia, LLC
+-- Copyright 2023 National Technology & Engineering Solutions of Sandia, LLC
 -- (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
 -- Government retains certain rights in this software.
 --
@@ -670,6 +670,61 @@ LEFT OUTER JOIN tool_runs AS tr
 -- ----------------------------------------------------------------------
 
 CREATE VIEW prowler_checks AS
+WITH cte1 AS (
+  SELECT DISTINCT
+      'aws'                       AS provider
+    , account_number              AS account_id
+    , region                      AS region
+    , control_id                  AS check_id
+    , NULL                        AS check_title
+    , service                     AS service_name
+    , NULL                        AS sub_service_name
+    , status                      AS status
+    , severity                    AS severity
+    , NULL                        AS status_extended
+    , resource_id                 AS resource_id
+    , control                     AS description
+    , risk                        AS risk
+    , NULL                        AS related_url
+    , remediation                 AS recommendation
+    , documentation_link          AS recommendation_url
+    , NULL                        AS remediation_code
+    , level                       AS compliance
+  FROM raw_prowler_v2_checks
+), cte2 AS (
+  SELECT DISTINCT
+      provider
+    , account_id
+    , region
+    , check_id
+    , check_title
+    , service_name
+    , sub_service_name
+    , status
+    , severity
+    , status_extended
+    , resource_id
+    , description
+    , risk
+    , related_url
+    , recommendation
+    , recommendation_url
+    , remediation_code
+    , compliance
+  FROM raw_prowler_v3_checks
+)
+SELECT DISTINCT
+  *
+FROM cte1
+UNION
+SELECT DISTINCT
+  *
+FROM cte2
+;
+
+-- ----------------------------------------------------------------------
+
+CREATE VIEW prowler_v2_checks AS
 SELECT DISTINCT
     account_number              AS account_number
   , timestamp                   AS timestamp
@@ -684,7 +739,7 @@ SELECT DISTINCT
   , remediation                 AS remediation
   , documentation_link          AS documentation_link
   , resource_id                 AS resource_id
-FROM raw_prowler_checks AS rpc
+FROM raw_prowler_v2_checks AS rpv2c
 ORDER BY account_number, region, level, control_id, service,
          status, severity, resource_id
 ;

--- a/datastore/common/utils/NetmeldPostgresConversions.cpp
+++ b/datastore/common/utils/NetmeldPostgresConversions.cpp
@@ -49,7 +49,7 @@ namespace pqxx {
   {
     return generic_to_buf(begin, end, obj);
   }
-  
+
   char*
   string_traits<nmco::Uuid>::into_buf(char* begin, char* end, const nmco::Uuid& obj)
   {

--- a/datastore/common/utils/QueriesCommon.cpp
+++ b/datastore/common/utils/QueriesCommon.cpp
@@ -1507,8 +1507,8 @@ namespace netmeld::datastore::utils {
     // ----------------------------------------------------------------------
 
     db.prepare
-    ("insert_raw_prowler_check", R"(
-        INSERT INTO raw_prowler_checks
+    ("insert_raw_prowler_v2_check", R"(
+        INSERT INTO raw_prowler_v2_checks
           (tool_run_id, account_number, timestamp, region,
            level, control_id, service,
            status, severity, control, risk, remediation, documentation_link,
@@ -1519,6 +1519,33 @@ namespace netmeld::datastore::utils {
            $5, $6, $7,
            $8, $9, $10, $11, $12, $13,
            $14)
+        ON CONFLICT
+        DO NOTHING
+      )");
+
+    db.prepare
+    ("insert_raw_prowler_v3_check", R"(
+        INSERT INTO raw_prowler_v3_checks
+          (tool_run_id, assessment_start_time,
+           finding_unique_id, provider, profile, account_id,
+           organizations_info, region, check_id, check_title,
+           check_types, service_name, sub_service_name, status,
+           status_extended, severity, resource_id,
+           resource_arn, resource_tags, resource_type,
+           resource_details, description, risk, related_url,
+           recommendation, recommendation_url, remediation_code,
+           categories, notes, compliance
+           )
+        VALUES
+          ( $1, $2, $3
+          , nullif($4, ''), nullif($5, ''), nullif($6, ''), nullif($7, '')
+          , nullif($8, ''), nullif($9, ''), nullif($10, ''), nullif($11, '')
+          , nullif($12, ''), nullif($13, ''), nullif($14, ''), nullif($15, '')
+          , $16, nullif($17, ''), nullif($18, ''), nullif($19, '')
+          , nullif($20, ''), nullif($21, ''), nullif($22, ''), nullif($23, '')
+          , nullif($24, ''), nullif($25, ''), nullif($26, ''), nullif($27, '')
+          , nullif($28, ''), nullif($29, ''), nullif($30, '')
+          )
         ON CONFLICT
         DO NOTHING
       )");

--- a/datastore/exporters/nmdb-export-scans/exporters/ExportScan.hpp
+++ b/datastore/exporters/nmdb-export-scans/exporters/ExportScan.hpp
@@ -1,5 +1,5 @@
 // =============================================================================
-// Copyright 2022 National Technology & Engineering Solutions of Sandia, LLC
+// Copyright 2023 National Technology & Engineering Solutions of Sandia, LLC
 // (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
 // Government retains certain rights in this software.
 //
@@ -33,7 +33,7 @@
 
 #include "../writers/Writer.hpp"
 
-namespace netmeld::export_scans {
+namespace netmeld::datastore::exporters::scans {
 
   // ==========================================================================
   // Primary object
@@ -68,8 +68,11 @@ namespace netmeld::export_scans {
           pqxx::read_transaction&, const std::string&
         ) const;
 
+      virtual void finalize(const std::unique_ptr<Writer>&) const = 0;
+
     public: // Methods part of public API
-      virtual void exportScan(const std::unique_ptr<Writer>&) = 0;
+      virtual void exportTemplate(const std::unique_ptr<Writer>&) const = 0;
+      virtual void exportFromDb(const std::unique_ptr<Writer>&) = 0;
   };
 }
 #endif // EXPORT_SCAN_HPP

--- a/datastore/exporters/nmdb-export-scans/exporters/InterNetwork.cpp
+++ b/datastore/exporters/nmdb-export-scans/exporters/InterNetwork.cpp
@@ -1,5 +1,5 @@
 // =============================================================================
-// Copyright 2022 National Technology & Engineering Solutions of Sandia, LLC
+// Copyright 2023 National Technology & Engineering Solutions of Sandia, LLC
 // (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
 // Government retains certain rights in this software.
 //
@@ -26,54 +26,46 @@
 
 #include "InterNetwork.hpp"
 
-namespace netmeld::export_scans {
+namespace netmeld::datastore::exporters::scans {
   // ========================================================================
   // Constructors
   // ========================================================================
   InterNetwork::InterNetwork(const std::string& dbConnInfo) :
     ExportScan(dbConnInfo)
   {
-    db.prepare(
-      "select_internetwork_scan_source",
-      R"(
-      SELECT DISTINCT src_ip_addr
-      FROM inter_network_ports
-      ORDER BY src_ip_addr
+    db.prepare("select_internetwork_scan_source", R"(
+        SELECT DISTINCT src_ip_addr
+        FROM inter_network_ports
+        ORDER BY src_ip_addr
       )");
 
-    db.prepare(
-      "select_internetwork_scan_router",
-      R"(
-      SELECT DISTINCT next_hop_ip_addr
-      FROM inter_network_ports
-      WHERE ($1 = src_ip_addr)
-      ORDER BY next_hop_ip_addr
+    db.prepare("select_internetwork_scan_router", R"(
+        SELECT DISTINCT next_hop_ip_addr
+        FROM inter_network_ports
+        WHERE ($1 = src_ip_addr)
+        ORDER BY next_hop_ip_addr
       )");
 
-    db.prepare(
-      "select_internetwork_scan_destination",
-      R"(
-      SELECT DISTINCT dst_ip_addr
-      FROM inter_network_ports
-      WHERE ($1 = src_ip_addr)
-        AND ($2 = next_hop_ip_addr)
-      ORDER BY dst_ip_addr
+    db.prepare("select_internetwork_scan_destination", R"(
+        SELECT DISTINCT dst_ip_addr
+        FROM inter_network_ports
+        WHERE ($1 = src_ip_addr)
+          AND ($2 = next_hop_ip_addr)
+        ORDER BY dst_ip_addr
       )");
 
-    db.prepare(
-      "select_internetwork_scan_port",
-      R"(
-      SELECT DISTINCT
-        protocol, port, port_state, port_reason
-      FROM inter_network_ports
-      WHERE ($1 = src_ip_addr)
-        AND ($2 = next_hop_ip_addr)
-        AND ($3 = dst_ip_addr)
-        AND ( ( ( ('open' = port_state) OR ('closed' = port_state) )
-                AND NOT ( ('ip' = protocol) OR ('' = protocol)
-                          OR ('-1' = port) ) )
-              OR ( ('-1' = port) AND ('open' = port_state) ) )
-      ORDER BY protocol, port, port_state, port_reason
+    db.prepare("select_internetwork_scan_port", R"(
+        SELECT DISTINCT
+          protocol, port, port_state, port_reason
+        FROM inter_network_ports
+        WHERE ($1 = src_ip_addr)
+          AND ($2 = next_hop_ip_addr)
+          AND ($3 = dst_ip_addr)
+          AND ( ( ( ('open' = port_state) OR ('closed' = port_state) )
+                  AND NOT ( ('ip' = protocol) OR ('' = protocol)
+                            OR ('-1' = port) ) )
+                OR ( ('-1' = port) AND ('open' = port_state) ) )
+        ORDER BY protocol, port, port_state, port_reason
       )");
   }
 
@@ -81,111 +73,99 @@ namespace netmeld::export_scans {
   // Methods
   // ========================================================================
   void
-  InterNetwork::exportTemplate(const auto& writer) const
+  InterNetwork::exportTemplate(const std::unique_ptr<Writer>& writer) const
   {
-    std::vector<std::vector<std::string>> data {
-      { "RTR_IP_01", "HOSTNAME", "DST_IP_01", "HOSTNAME",
-        "NUM", "PROTO", "STATE", "REASON"
-      },
-      { "RTR_IP_02", "HOSTNAME", "DST_IP_02", "HOSTNAME",
-        "NUM", "PROTO", "STATE", "REASON"
-      },
-      { "RTR_IP_02", "HOSTNAME", "DST_IP_03", "HOSTNAME",
-        "NUM", "PROTO", "STATE", "REASON"
-      },
-      { "RTR_IP_03", "HOSTNAME", "DST_IP_04", "HOSTNAME",
-        "NUM", "PROTO", "STATE", "REASON"
-      },
-      { "RTR_IP_03", "HOSTNAME", "DST_IP_04", "HOSTNAME",
-        "NUM", "PROTO", "STATE", "REASON"
-      },
-      { "RTR_IP_04", "HOSTNAME", "DST_IP_04", "HOSTNAME",
-        "NUM", "PROTO", "STATE", "REASON"
-      },
-    };
-    for (const auto& entry : data) {
+    std::vector<std::tuple<std::string, std::string>> tuples {
+        { "RTR_IP_01", "DST_IP_01" }
+      , { "RTR_IP_02", "DST_IP_02" }
+      , { "RTR_IP_02", "DST_IP_03" }
+      , { "RTR_IP_03", "DST_IP_04" }
+      , { "RTR_IP_03", "DST_IP_04" }
+      , { "RTR_IP_04", "DST_IP_04" }
+      };
+
+    for (const auto& [rtrIp, dstIp] : tuples) {
+      std::vector<std::string> entry {
+          rtrIp, "HOSTNAME"
+        , dstIp, "HOSTNAME"
+        , "NUM", "PROTO", "STATE", "REASON"
+        };
+      
       writer->addRow(entry);
     }
+
+    finalize(writer);
   }
 
   void
-  InterNetwork::exportFromDb(const auto& writer, const std::string& srcIp)
+  InterNetwork::exportFromDb(const std::unique_ptr<Writer>& writer)
   {
-    pqxx::read_transaction t {db};
+    bool empty {true};
+    pqxx::read_transaction rt {db};
+    for ( const auto& sourceRow
+        : rt.exec_prepared("select_internetwork_scan_source")
+        )
+    {
+      empty = false;
+      srcIp = sourceRow.at(0).c_str();
 
-    pqxx::result routerRows
-      {t.exec_prepared("select_internetwork_scan_router", srcIp)};
-    for (const auto& routerRow : routerRows) {
-      std::string rtrIp;
-      routerRow.at("next_hop_ip_addr").to(rtrIp);
+      for ( const auto& routerRow
+          : rt.exec_prepared("select_internetwork_scan_router", srcIp)
+          )
+      {
+        std::string rtrIp   {routerRow.at("next_hop_ip_addr").c_str()};
+        std::string rtrName {getHostname(rt, rtrIp)};
 
-      std::string rtrName {getHostname(t, rtrIp)};
+        for ( const auto& destinationRow
+            : rt.exec_prepared("select_internetwork_scan_destination"
+                              , srcIp, rtrIp
+                              )
+            )
+        {
+          std::string dstIp     {destinationRow.at("dst_ip_addr").c_str()};
+          std::string dstIpName {getHostname(rt, dstIp)};
 
-      pqxx::result destinationRows {
-        t.exec_prepared("select_internetwork_scan_destination", srcIp, rtrIp)
-      };
-      for (const auto& destinationRow : destinationRows) {
-        std::string dstIp;
-        destinationRow.at("dst_ip_addr").to(dstIp);
+          for ( const auto& portRow
+              : rt.exec_prepared("select_internetwork_scan_port"
+                                , srcIp, rtrIp, dstIp
+                                )
+              )
+          {
+            std::string protocol    {portRow.at("protocol").c_str()};
+            std::string port        {portRow.at("port").c_str()};
+            std::string portState   {portRow.at("port_state").c_str()};
+            std::string portReason  {portRow.at("port_reason").c_str()};
 
-        std::string dstIpName {getHostname(t, dstIp)};
+            if ("-1" == port) {
+              port = "other";
+            }
 
-        pqxx::result portRows {
-          t.exec_prepared("select_internetwork_scan_port",
-              srcIp, rtrIp, dstIp)
-        };
-        for (const auto& portRow : portRows) {
-          std::string protocol;
-          portRow.at("protocol").to(protocol);
-          std::string port;
-          portRow.at("port").to(port);
-          std::string portState;
-          portRow.at("port_state").to(portState);
-          std::string portReason;
-          portRow.at("port_reason").to(portReason);
-
-          if ("-1" == port) {
-            port = "other";
+            std::vector<std::string> entry {
+                rtrIp, rtrName
+              , dstIp, dstIpName
+              , port, protocol, portState, portReason
+            };
+            writer->addRow(entry);
           }
-
-          std::vector<std::string> data {
-            rtrIp, rtrName, dstIp, dstIpName,
-            port, protocol, portState, portReason
-          };
-          writer->addRow(data);
         }
       }
+
+      finalize(writer);
     }
-    t.abort();
+
+    if (empty) {
+      finalize(writer);
+    }
   }
 
   void
-  InterNetwork::exportScan(const std::unique_ptr<Writer>& writer)
+  InterNetwork::finalize(const std::unique_ptr<Writer>& writer) const
   {
-    pqxx::read_transaction t {db};
+    LOG_DEBUG << "Finalizing data output\n";
 
-    pqxx::result sourceRows
-      {t.exec_prepared("select_internetwork_scan_source")};
-    t.abort();
+    std::string filename {"inter-network-from-" + srcIp};
 
-    auto fWrite = [&](const std::string& srcIp) {
-      writer->writeData(
-        "inter-network-from-" + srcIp,
-        writer->getInterNetwork(srcIp)
-      );
-      writer->clearData();
-    };
-
-    std::string srcIp {"IP/CIDR"};
-    if (0 == sourceRows.size()) {
-      exportTemplate(writer);
-      fWrite(srcIp);
-    } else {
-      for (const auto& sourceRow : sourceRows) {
-        sourceRow.at("src_ip_addr").to(srcIp);
-        exportFromDb(writer, srcIp);
-        fWrite(srcIp);
-      }
-    }
+    writer->writeData(filename, writer->getInterNetwork(srcIp));
+    writer->clearData();
   }
 }

--- a/datastore/exporters/nmdb-export-scans/exporters/InterNetwork.cpp
+++ b/datastore/exporters/nmdb-export-scans/exporters/InterNetwork.cpp
@@ -90,7 +90,7 @@ namespace netmeld::datastore::exporters::scans {
         , dstIp, "HOSTNAME"
         , "NUM", "PROTO", "STATE", "REASON"
         };
-      
+
       writer->addRow(entry);
     }
 

--- a/datastore/exporters/nmdb-export-scans/exporters/InterNetwork.hpp
+++ b/datastore/exporters/nmdb-export-scans/exporters/InterNetwork.hpp
@@ -1,5 +1,5 @@
 // =============================================================================
-// Copyright 2022 National Technology & Engineering Solutions of Sandia, LLC
+// Copyright 2023 National Technology & Engineering Solutions of Sandia, LLC
 // (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
 // Government retains certain rights in this software.
 //
@@ -29,7 +29,7 @@
 
 #include "ExportScan.hpp"
 
-namespace netmeld::export_scans {
+namespace netmeld::datastore::exporters::scans {
   // ==========================================================================
   // Primary object
   // ==========================================================================
@@ -38,6 +38,8 @@ namespace netmeld::export_scans {
     // Variables
     // ======================================================================
     private: // Variables should generally be private
+      std::string srcIp {"IP"};
+
     protected: // Variables intended for internal/subclass API
     public: // Variables should rarely appear at this scope
 
@@ -54,12 +56,12 @@ namespace netmeld::export_scans {
     // Methods
     // ======================================================================
     private: // Methods which should be hidden from API users
-      void exportTemplate(const auto&) const;
-      void exportFromDb(const auto&, const std::string&);
-
     protected: // Methods part of subclass API
+      void finalize(const std::unique_ptr<Writer>&) const override;
+
     public: // Methods part of public API
-      void exportScan(const std::unique_ptr<Writer>&) override;
+      void exportTemplate(const std::unique_ptr<Writer>&) const override;
+      void exportFromDb(const std::unique_ptr<Writer>&) override;
   };
 }
 #endif // EXPORT_SCAN_INTER_NETWORK_HPP

--- a/datastore/exporters/nmdb-export-scans/exporters/IntraNetwork.cpp
+++ b/datastore/exporters/nmdb-export-scans/exporters/IntraNetwork.cpp
@@ -85,11 +85,11 @@ namespace netmeld::datastore::exporters::scans {
       };
     for (const auto& dstIp : ips) {
       std::vector<std::string> entry {
-          dstIp, "HOSTNAME" 
+          dstIp, "HOSTNAME"
         , "PORT", "PROTOCOL", "STATE", "REASON"
         , "SERVICE_NAME", "SERVICE_REASON"
         };
-      
+
       writer->addRow(entry);
     }
 

--- a/datastore/exporters/nmdb-export-scans/exporters/IntraNetwork.cpp
+++ b/datastore/exporters/nmdb-export-scans/exporters/IntraNetwork.cpp
@@ -1,5 +1,5 @@
 // =============================================================================
-// Copyright 2022 National Technology & Engineering Solutions of Sandia, LLC
+// Copyright 2023 National Technology & Engineering Solutions of Sandia, LLC
 // (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
 // Government retains certain rights in this software.
 //
@@ -26,56 +26,48 @@
 
 #include "IntraNetwork.hpp"
 
-namespace netmeld::export_scans {
+namespace netmeld::datastore::exporters::scans {
   // ========================================================================
   // Constructors
   // ========================================================================
   IntraNetwork::IntraNetwork(const std::string& dbConnInfo) :
     ExportScan(dbConnInfo)
   {
-    db.prepare(
-      "select_intranetwork_scan_source",
-      R"(
-      SELECT DISTINCT src_ip_addr
-      FROM intra_network_ports
-      ORDER BY src_ip_addr
+    db.prepare("select_intranetwork_scan_source", R"(
+        SELECT DISTINCT src_ip_addr
+        FROM intra_network_ports
+        ORDER BY src_ip_addr
       )");
 
-    db.prepare(
-      "select_intranetwork_scan_destination",
-      R"(
-      SELECT DISTINCT dst_ip_addr
-      FROM intra_network_ports
-      WHERE ($1 = src_ip_addr)
-      ORDER BY dst_ip_addr
+    db.prepare("select_intranetwork_scan_destination", R"(
+        SELECT DISTINCT dst_ip_addr
+        FROM intra_network_ports
+        WHERE ($1 = src_ip_addr)
+        ORDER BY dst_ip_addr
       )");
 
-    db.prepare(
-      "select_intranetwork_scan_port",
-      R"(
-      SELECT DISTINCT
-        protocol, port, port_state, port_reason
-      FROM intra_network_ports
-      WHERE ($1 = src_ip_addr)
-        AND ($2 = dst_ip_addr)
-        AND ( ( ( ('open' = port_state) OR ('closed' = port_state) )
-                AND NOT ( ('ip' = protocol)
-                          OR ('' = protocol)
-                          OR ('-1' = port) ) )
-              OR ( ('-1' = port) AND ('open' = port_state) ) )
-      ORDER BY protocol, port, port_state, port_reason
+    db.prepare("select_intranetwork_scan_port", R"(
+        SELECT DISTINCT
+          protocol, port, port_state, port_reason
+        FROM intra_network_ports
+        WHERE ($1 = src_ip_addr)
+          AND ($2 = dst_ip_addr)
+          AND ( ( ( ('open' = port_state) OR ('closed' = port_state) )
+                  AND NOT ( ('ip' = protocol)
+                            OR ('' = protocol)
+                            OR ('-1' = port) ) )
+                OR ( ('-1' = port) AND ('open' = port_state) ) )
+        ORDER BY protocol, port, port_state, port_reason
       )");
 
-    db.prepare(
-      "select_intranetwork_scan_service",
-      R"(
-      SELECT DISTINCT
-        service_name, service_description, service_reason
-      FROM network_services
-      WHERE ($1 = ip_addr)
-        AND ($2 = protocol)
-        AND ($3 = port)
-      ORDER BY service_reason
+    db.prepare("select_intranetwork_scan_service", R"(
+        SELECT DISTINCT
+          service_name, service_description, service_reason
+        FROM network_services
+        WHERE ($1 = ip_addr)
+          AND ($2 = protocol)
+          AND ($3 = port)
+        ORDER BY service_reason
       )");
   }
 
@@ -83,117 +75,105 @@ namespace netmeld::export_scans {
   // Methods
   // ========================================================================
   void
-  IntraNetwork::exportTemplate(const auto& writer) const
+  IntraNetwork::exportTemplate(const std::unique_ptr<Writer>& writer) const
   {
-    std::vector<std::vector<std::string>> data {
-      { "IP_01", "HOSTNAME", "NUM", "PROTO", "STATE", "REASON",
-        "NAME", "DESCRIPTION"
-      },
-      { "IP_02", "HOSTNAME", "NUM", "PROTO", "STATE", "REASON",
-        "NAME", "DESCRIPTION"
-      },
-      { "IP_02", "HOSTNAME", "NUM", "PROTO", "STATE", "REASON",
-        "NAME", "DESCRIPTION"
-      },
-      { "IP_03", "HOSTNAME", "NUM", "PROTO", "STATE", "REASON",
-        "NAME", "DESCRIPTION"
-      },
-    };
-    for (const auto& entry : data) {
+    std::vector<std::string> ips {
+        "IP_01"
+      , "IP_02"
+      , "IP_02"
+      , "IP_03"
+      };
+    for (const auto& dstIp : ips) {
+      std::vector<std::string> entry {
+          dstIp, "HOSTNAME" 
+        , "PORT", "PROTOCOL", "STATE", "REASON"
+        , "SERVICE_NAME", "SERVICE_REASON"
+        };
+      
       writer->addRow(entry);
     }
+
+    finalize(writer);
   }
 
   void
-  IntraNetwork::exportFromDb(const auto& writer, const std::string& srcIp)
+  IntraNetwork::exportFromDb(const std::unique_ptr<Writer>& writer)
   {
-    pqxx::read_transaction t {db};
-    pqxx::result destinationRows
-      {t.exec_prepared("select_intranetwork_scan_destination", srcIp)};
+    bool empty {true};
+    pqxx::read_transaction rt {db};
+    for ( const auto& sourceRow
+        : rt.exec_prepared("select_intranetwork_scan_source")
+        )
+    {
+      empty = false;
+      srcIp = sourceRow.at(0).c_str();
 
-    for (const auto& destinationRow : destinationRows) {
-      std::string dstIp;
-      destinationRow.at("dst_ip_addr").to(dstIp);
+      for ( const auto& destinationRow
+          : rt.exec_prepared("select_intranetwork_scan_destination", srcIp)
+          )
+      {
+        std::string dstIp     {destinationRow.at("dst_ip_addr").c_str()};
+        std::string dstIpName {getHostname(rt, dstIp)};
 
-      std::string dstIpName {getHostname(t, dstIp)};
+        for ( const auto& portRow
+            : rt.exec_prepared("select_intranetwork_scan_port", srcIp, dstIp)
+            )
+        {
+          std::string protocol    {portRow.at("protocol").c_str()};
+          std::string port        {portRow.at("port").c_str()};
+          std::string portState   {portRow.at("port_state").c_str()};
+          std::string portReason  {portRow.at("port_reason").c_str()};
 
-      pqxx::result portRows
-        {t.exec_prepared("select_intranetwork_scan_port", srcIp, dstIp)};
-
-      for (const auto& portRow : portRows) {
-        std::string protocol;
-        portRow.at("protocol").to(protocol);
-        std::string port;
-        portRow.at("port").to(port);
-        std::string portState;
-        portRow.at("port_state").to(portState);
-        std::string portReason;
-        portRow.at("port_reason").to(portReason);
-
-        pqxx::result serviceRows {
-          t.exec_prepared("select_intranetwork_scan_service",
-                          dstIp, protocol, port)
-        };
-
-        std::string serviceName;
-        std::string serviceDesc;
-        for (const auto& serviceRow : serviceRows) {
-          std::string tmpSrvcName;
-          serviceRow.at("service_name").to(tmpSrvcName);
-          std::string tmpSrvcDesc;
-          serviceRow.at("service_description").to(tmpSrvcDesc);
-          std::string tmpSrvcReason;
-          serviceRow.at("service_reason").to(tmpSrvcReason);
-
-          if (   ("probed" == tmpSrvcReason)
-              || (serviceName.empty() && "unknown" != tmpSrvcName))
-          {
-            serviceName = tmpSrvcName;
-            serviceDesc = tmpSrvcDesc;
+          if ("-1" == port) { // short circuit, protocol scan result
+            continue;
           }
-        }
 
-        if ("-1" == port) {
-          continue;
-        }
+          std::string serviceName;
+          std::string serviceDesc;
+          for ( const auto& serviceRow
+              : rt.exec_prepared("select_intranetwork_scan_service"
+                                , dstIp, protocol, port
+                                )
+              )
+          {
+            std::string srvcName   {serviceRow.at("service_name").c_str()};
+            std::string srvcDesc   {serviceRow.at("service_description").c_str()};
+            std::string srvcReason {serviceRow.at("service_reason").c_str()};
 
-        std::vector<std::string> data {
-          dstIp, dstIpName, port, protocol, portState, portReason,
-          serviceName, serviceDesc
-        };
-        writer->addRow(data);
+            if (  ("probed" == srvcReason)
+               || (serviceName.empty() && "unknown" != srvcName)
+               )
+            {
+              serviceName = srvcName;
+              serviceDesc = srvcDesc;
+            }
+          }
+
+          std::vector<std::string> entry {
+              dstIp, dstIpName
+            , port, protocol, portState, portReason
+            , serviceName, serviceDesc
+          };
+          writer->addRow(entry);
+        }
       }
+
+      finalize(writer);
     }
-    t.abort();
+
+    if (empty) {
+      finalize(writer);
+    }
   }
 
   void
-  IntraNetwork::exportScan(const std::unique_ptr<Writer>& writer)
+  IntraNetwork::finalize(const std::unique_ptr<Writer>& writer) const
   {
-    pqxx::read_transaction t {db};
+    LOG_DEBUG << "Finalizing data output\n";
 
-    pqxx::result sourceRows
-      {t.exec_prepared("select_intranetwork_scan_source")};
-    t.abort();
+    std::string filename {"intra-network-from-" + srcIp};
 
-    auto fWrite = [&](const std::string& srcIp) {
-      writer->writeData(
-        "intra-network-from-" + srcIp,
-        writer->getIntraNetwork(srcIp)
-      );
-      writer->clearData();
-    };
-
-    std::string srcIp {"IP/CIDR"};
-    if (0 == sourceRows.size()) {
-      exportTemplate(writer);
-      fWrite(srcIp);
-    } else {
-      for (const auto& sourceRow : sourceRows) {
-        sourceRow.at("src_ip_addr").to(srcIp);
-        exportFromDb(writer, srcIp);
-        fWrite(srcIp);
-      }
-    }
+    writer->writeData(filename, writer->getIntraNetwork(srcIp));
+    writer->clearData();
   }
 }

--- a/datastore/exporters/nmdb-export-scans/exporters/IntraNetwork.hpp
+++ b/datastore/exporters/nmdb-export-scans/exporters/IntraNetwork.hpp
@@ -1,5 +1,5 @@
 // =============================================================================
-// Copyright 2022 National Technology & Engineering Solutions of Sandia, LLC
+// Copyright 2023 National Technology & Engineering Solutions of Sandia, LLC
 // (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
 // Government retains certain rights in this software.
 //
@@ -29,7 +29,7 @@
 
 #include "ExportScan.hpp"
 
-namespace netmeld::export_scans {
+namespace netmeld::datastore::exporters::scans {
   // ============================================================================
   // Primary object
   // ============================================================================
@@ -38,6 +38,8 @@ namespace netmeld::export_scans {
     // Variables
     // ========================================================================
     private: // Variables should generally be private
+      std::string srcIp {"IP"};
+
     protected: // Variables intended for internal/subclass API
     public: // Variables should rarely appear at this scope
 
@@ -54,12 +56,12 @@ namespace netmeld::export_scans {
     // Methods
     // ========================================================================
     private: // Methods which should be hidden from API users
-      void exportTemplate(const auto&) const;
-      void exportFromDb(const auto&, const std::string&);
-
     protected: // Methods part of subclass API
+      void finalize(const std::unique_ptr<Writer>&) const override;
+
     public: // Methods part of public API
-      void exportScan(const std::unique_ptr<Writer>&) override;
+      void exportTemplate(const std::unique_ptr<Writer>&) const override;
+      void exportFromDb(const std::unique_ptr<Writer>&) override;
   };
 }
 #endif // EXPORT_SCAN_INTRA_NETWORK_HPP

--- a/datastore/exporters/nmdb-export-scans/exporters/Nessus.hpp
+++ b/datastore/exporters/nmdb-export-scans/exporters/Nessus.hpp
@@ -1,5 +1,5 @@
 // =============================================================================
-// Copyright 2022 National Technology & Engineering Solutions of Sandia, LLC
+// Copyright 2023 National Technology & Engineering Solutions of Sandia, LLC
 // (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
 // Government retains certain rights in this software.
 //
@@ -29,37 +29,39 @@
 
 #include "ExportScan.hpp"
 
-namespace netmeld::export_scans {
-// ============================================================================
-// Primary object
-// ============================================================================
-class Nessus : public ExportScan {
-  // ========================================================================
-  // Variables
-  // ========================================================================
-  private: // Variables should generally be private
-  protected: // Variables intended for internal/subclass API
-  public: // Variables should rarely appear at this scope
+namespace netmeld::datastore::exporters::scans {
+  // ==========================================================================
+  // Primary object
+  // ==========================================================================
+  class Nessus : public ExportScan {
+    // ========================================================================
+    // Variables
+    // ========================================================================
+    private: // Variables should generally be private
+      const std::string filePrefix {"intra-network-from-"};
 
-  // ========================================================================
-  // Constructors
-  // ========================================================================
-  private: // Constructors which should be hidden from API users
-  protected: // Constructors part of subclass API
-  public: // Constructors part of public API
-    Nessus() = delete;
-    explicit Nessus(const std::string&);
+    protected: // Variables intended for internal/subclass API
+    public: // Variables should rarely appear at this scope
 
-  // ========================================================================
-  // Methods
-  // ========================================================================
-  private: // Methods which should be hidden from API users
-    void exportTemplate(const auto&) const;
-    void exportFromDb(const auto&, const pqxx::result&);
+    // ========================================================================
+    // Constructors
+    // ========================================================================
+    private: // Constructors which should be hidden from API users
+    protected: // Constructors part of subclass API
+    public: // Constructors part of public API
+      Nessus() = delete;
+      explicit Nessus(const std::string&);
 
-  protected: // Methods part of subclass API
-  public: // Methods part of public API
-    void exportScan(const std::unique_ptr<Writer>&)override;
-};
+    // ========================================================================
+    // Methods
+    // ========================================================================
+    private: // Methods which should be hidden from API users
+    protected: // Methods part of subclass API
+      void finalize(const std::unique_ptr<Writer>&) const;
+
+    public: // Methods part of public API
+      void exportTemplate(const std::unique_ptr<Writer>&) const override;
+      void exportFromDb(const std::unique_ptr<Writer>&) override;
+  };
 }
 #endif // EXPORT_SCAN_NESSUS_HPP

--- a/datastore/exporters/nmdb-export-scans/exporters/Prowler.hpp
+++ b/datastore/exporters/nmdb-export-scans/exporters/Prowler.hpp
@@ -1,5 +1,5 @@
 // =============================================================================
-// Copyright 2022 National Technology & Engineering Solutions of Sandia, LLC
+// Copyright 2023 National Technology & Engineering Solutions of Sandia, LLC
 // (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
 // Government retains certain rights in this software.
 //
@@ -29,37 +29,37 @@
 
 #include "ExportScan.hpp"
 
-namespace netmeld::export_scans {
-// ============================================================================
-// Primary object
-// ============================================================================
-class Prowler : public ExportScan {
-  // ========================================================================
-  // Variables
-  // ========================================================================
-  private: // Variables should generally be private
-  protected: // Variables intended for internal/subclass API
-  public: // Variables should rarely appear at this scope
+namespace netmeld::datastore::exporters::scans {
+  // ==========================================================================
+  // Primary object
+  // ==========================================================================
+  class Prowler : public ExportScan {
+    // ========================================================================
+    // Variables
+    // ========================================================================
+    private: // Variables should generally be private
+    protected: // Variables intended for internal/subclass API
+    public: // Variables should rarely appear at this scope
 
-  // ========================================================================
-  // Constructors
-  // ========================================================================
-  private: // Constructors which should be hidden from API users
-  protected: // Constructors part of subclass API
-  public: // Constructors part of public API
-    Prowler() = delete;
-    explicit Prowler(const std::string&);
+    // ========================================================================
+    // Constructors
+    // ========================================================================
+    private: // Constructors which should be hidden from API users
+    protected: // Constructors part of subclass API
+    public: // Constructors part of public API
+      Prowler() = delete;
+      explicit Prowler(const std::string&);
 
-  // ========================================================================
-  // Methods
-  // ========================================================================
-  private: // Methods which should be hidden from API users
-    void exportTemplate(const auto&) const;
-    void exportFromDb(const auto&, const pqxx::result&);
+    // ========================================================================
+    // Methods
+    // ========================================================================
+    private: // Methods which should be hidden from API users
+    protected: // Methods part of subclass API
+      void finalize(const std::unique_ptr<Writer>&) const override;
 
-  protected: // Methods part of subclass API
-  public: // Methods part of public API
-    void exportScan(const std::unique_ptr<Writer>&)override;
-};
+    public: // Methods part of public API
+      void exportTemplate(const std::unique_ptr<Writer>&) const override;
+      void exportFromDb(const std::unique_ptr<Writer>&) override;
+  };
 }
 #endif // EXPORT_SCAN_PROWLER_HPP

--- a/datastore/exporters/nmdb-export-scans/exporters/SshAlgorithms.hpp
+++ b/datastore/exporters/nmdb-export-scans/exporters/SshAlgorithms.hpp
@@ -1,5 +1,5 @@
 // =============================================================================
-// Copyright 2022 National Technology & Engineering Solutions of Sandia, LLC
+// Copyright 2023 National Technology & Engineering Solutions of Sandia, LLC
 // (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
 // Government retains certain rights in this software.
 //
@@ -29,126 +29,126 @@
 
 #include "ExportScan.hpp"
 
-namespace netmeld::export_scans {
-// ============================================================================
-// Primary object
-// ============================================================================
-class SshAlgorithms : public ExportScan {
-  // ========================================================================
-  // Variables
-  // ========================================================================
-  private: // Variables should generally be private
-    // colors
-    const std::string good  {"darkgreen"};
-    const std::string bad   {"red"};
-    const std::string unk   {"black"};
+namespace netmeld::datastore::exporters::scans {
+  // ==========================================================================
+  // Primary object
+  // ==========================================================================
+  class SshAlgorithms : public ExportScan {
+    // ========================================================================
+    // Variables
+    // ========================================================================
+    private: // Variables should generally be private
+      // colors
+      const std::string good  {"darkgreen"};
+      const std::string bad   {"red"};
+      const std::string unk   {"black"};
 
-    // algorithms: identified good/bad
-    // NOTE: separately called out for easier tracking
-    const std::map<std::string, std::string> algoComp
-    {
-    };
-    const std::map<std::string, std::string> algoEnc
-    {
-      {"aes128-ctr", good},
-      {"aes256-ctr", good},
-      {"aes128-gcm@openssh.com", good},
-      {"aes256-gcm@openssh.com", good},
+      // algorithms: identified good/bad
+      // NOTE: separately called out for easier tracking
+      const std::map<std::string, std::string> algoComp
+      {
+      };
+      const std::map<std::string, std::string> algoEnc
+      {
+        {"aes128-ctr", good},
+        {"aes256-ctr", good},
+        {"aes128-gcm@openssh.com", good},
+        {"aes256-gcm@openssh.com", good},
 
-      {"none", bad},
-      {"3des-cbc", bad},
-      {"blowfish-cbc", bad},
-      {"twofish-cbc", bad},
-      {"twofish128-cbc", bad},
-      {"twofish256-cbc", bad},
-      {"cast128-cbc", bad},
-      {"arcfour", bad},
-      {"arcfour128", bad},
-      {"arcfour256", bad},
-      {"aes128-cbc", bad},
-      {"aes192-cbc", bad},
-      {"aes256-cbc", bad},
-      {"rijndael128-cbc", bad},
-      {"rijndael192-cbc", bad},
-      {"rijndael256-cbc", bad},
-      {"rijndael-cbc@lysator.liu.se", bad}
-    };
-    const std::map<std::string, std::string> algoKex
-    {
-      {"curve25519-sha256", good},
-      {"curve25519-sha256@libssh.org", good},
-      {"diffie-hellman-group14-sha256", good},
-      {"diffie-hellman-group16-sha512", good},
-      {"diffie-hellman-group18-sha512", good},
-      {"diffie-hellman-group-exchange-sha256", good},
+        {"none", bad},
+        {"3des-cbc", bad},
+        {"blowfish-cbc", bad},
+        {"twofish-cbc", bad},
+        {"twofish128-cbc", bad},
+        {"twofish256-cbc", bad},
+        {"cast128-cbc", bad},
+        {"arcfour", bad},
+        {"arcfour128", bad},
+        {"arcfour256", bad},
+        {"aes128-cbc", bad},
+        {"aes192-cbc", bad},
+        {"aes256-cbc", bad},
+        {"rijndael128-cbc", bad},
+        {"rijndael192-cbc", bad},
+        {"rijndael256-cbc", bad},
+        {"rijndael-cbc@lysator.liu.se", bad}
+      };
+      const std::map<std::string, std::string> algoKex
+      {
+        {"curve25519-sha256", good},
+        {"curve25519-sha256@libssh.org", good},
+        {"diffie-hellman-group14-sha256", good},
+        {"diffie-hellman-group16-sha512", good},
+        {"diffie-hellman-group18-sha512", good},
+        {"diffie-hellman-group-exchange-sha256", good},
 
-      {"diffie-hellman-group1-sha1", bad},
-      {"diffie-hellman-group-exchange-sha1", bad}
-    };
-    const std::map<std::string, std::string> algoMac
-    {
-      {"hmac-sha2-256-etm@openssh.com", good},
-      {"hmac-sha2-512-etm@openssh.com", good},
-      {"umac-128-etm@openssh.com", good},
+        {"diffie-hellman-group1-sha1", bad},
+        {"diffie-hellman-group-exchange-sha1", bad}
+      };
+      const std::map<std::string, std::string> algoMac
+      {
+        {"hmac-sha2-256-etm@openssh.com", good},
+        {"hmac-sha2-512-etm@openssh.com", good},
+        {"umac-128-etm@openssh.com", good},
 
-      {"none", bad},
-      {"hmac-sha1-96", bad},
-      {"hmac-sha2-256-96", bad},
-      {"hmac-sha2-512-96", bad},
-      {"hmac-md5", bad},
-      {"hmac-md5-96", bad},
-      {"hmac-ripemd160", bad},
-      {"hmac-ripemd160@openssh.com", bad},
-      {"hmac-sha1-96-etm@openssh.com", bad},
-      {"hmac-md5-etm@openssh.com", bad},
-      {"hmac-md5-96-etm@openssh.com", bad},
-      {"hmac-ripemd160-etm@openssh.com", bad}
-    };
-    const std::map<std::string, std::string> algoKey
-    {
-      {"ssh-ed25519-cert-v01@openssh.com", good},
-      {"ssh-rsa-cert-v01@openssh.com", good},
-      {"ssh-ed25519", good},
-      {"ssh-rsa", good},
+        {"none", bad},
+        {"hmac-sha1-96", bad},
+        {"hmac-sha2-256-96", bad},
+        {"hmac-sha2-512-96", bad},
+        {"hmac-md5", bad},
+        {"hmac-md5-96", bad},
+        {"hmac-ripemd160", bad},
+        {"hmac-ripemd160@openssh.com", bad},
+        {"hmac-sha1-96-etm@openssh.com", bad},
+        {"hmac-md5-etm@openssh.com", bad},
+        {"hmac-md5-96-etm@openssh.com", bad},
+        {"hmac-ripemd160-etm@openssh.com", bad}
+      };
+      const std::map<std::string, std::string> algoKey
+      {
+        {"ssh-ed25519-cert-v01@openssh.com", good},
+        {"ssh-rsa-cert-v01@openssh.com", good},
+        {"ssh-ed25519", good},
+        {"ssh-rsa", good},
 
-      {"ssh-dss", bad},
-      {"ssh-rsa-cert-v00@openssh.com", bad},
-      {"ssh-dss-cert-v00@openssh.com", bad},
-      {"ssh-dss-cert-v01@openssh.com", bad}
-    };
+        {"ssh-dss", bad},
+        {"ssh-rsa-cert-v00@openssh.com", bad},
+        {"ssh-dss-cert-v00@openssh.com", bad},
+        {"ssh-dss-cert-v01@openssh.com", bad}
+      };
 
-    // NOTE: container for easier searching
-    const std::map<std::string, std::map<std::string, std::string>> algorithms
-    {
-      {"compression_algorithms", algoComp},
-      {"encryption_algorithms", algoEnc},
-      {"kex_algorithms", algoKex},
-      {"mac_algorithms", algoMac},
-      {"server_host_key_algorithms", algoKey},
-    };
+      // NOTE: container for easier searching
+      const std::map<std::string, std::map<std::string, std::string>> algorithms
+      {
+        {"compression_algorithms", algoComp},
+        {"encryption_algorithms", algoEnc},
+        {"kex_algorithms", algoKex},
+        {"mac_algorithms", algoMac},
+        {"server_host_key_algorithms", algoKey},
+      };
 
-  protected: // Variables intended for internal/subclass API
-  public: // Variables should rarely appear at this scope
+    protected: // Variables intended for internal/subclass API
+    public: // Variables should rarely appear at this scope
 
-  // ========================================================================
-  // Constructors
-  // ========================================================================
-  private: // Constructors which should be hidden from API users
-  protected: // Constructors part of subclass API
-  public: // Constructors part of public API
-    SshAlgorithms() = delete;
-    explicit SshAlgorithms(const std::string&);
+    // ========================================================================
+    // Constructors
+    // ========================================================================
+    private: // Constructors which should be hidden from API users
+    protected: // Constructors part of subclass API
+    public: // Constructors part of public API
+      SshAlgorithms() = delete;
+      explicit SshAlgorithms(const std::string&);
 
-  // ========================================================================
-  // Methods
-  // ========================================================================
-  private: // Methods which should be hidden from API users
-    void exportTemplate(const auto&) const;
-    void exportFromDb(const auto&, const pqxx::result&);
+    // ========================================================================
+    // Methods
+    // ========================================================================
+    private: // Methods which should be hidden from API users
+    protected: // Methods part of subclass API
+      void finalize(const std::unique_ptr<Writer>&) const override;
 
-  protected: // Methods part of subclass API
-  public: // Methods part of public API
-    void exportScan(const std::unique_ptr<Writer>&) override;
-};
+    public: // Methods part of public API
+      void exportTemplate(const std::unique_ptr<Writer>&) const override;
+      void exportFromDb(const std::unique_ptr<Writer>&) override;
+  };
 }
 #endif // EXPORT_SCAN_SSH_ALGORITHMS_HPP

--- a/datastore/exporters/nmdb-export-scans/nmdb-export-scans.cpp
+++ b/datastore/exporters/nmdb-export-scans/nmdb-export-scans.cpp
@@ -185,7 +185,7 @@ class Tool : public nmdt::AbstractExportTool
     void
     doExport(auto& exporter, auto& writer) {
       if (opts.exists("template")) {
-        LOG_DEBUG << "Exporting template data\n";        
+        LOG_DEBUG << "Exporting template data\n";
         exporter.exportTemplate(writer);
       } else {
         LOG_DEBUG << "Exporting DB data\n";

--- a/datastore/exporters/nmdb-export-scans/nmdb-export-scans.cpp
+++ b/datastore/exporters/nmdb-export-scans/nmdb-export-scans.cpp
@@ -1,5 +1,5 @@
 // =============================================================================
-// Copyright 2022 National Technology & Engineering Solutions of Sandia, LLC
+// Copyright 2023 National Technology & Engineering Solutions of Sandia, LLC
 // (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
 // Government retains certain rights in this software.
 //
@@ -30,20 +30,21 @@
 #include <netmeld/core/utils/StringUtilities.hpp>
 #include <netmeld/datastore/tools/AbstractExportTool.hpp>
 
+#include "exporters/ExportScan.hpp"
 #include "exporters/InterNetwork.hpp"
 #include "exporters/IntraNetwork.hpp"
 #include "exporters/Nessus.hpp"
 #include "exporters/Prowler.hpp"
 #include "exporters/SshAlgorithms.hpp"
-#include "writers/Writer.hpp"
 #include "writers/Context.hpp"
 #include "writers/Csv.hpp"
+#include "writers/Writer.hpp"
 
 namespace nmcu = netmeld::core::utils;
 namespace nmdt = netmeld::datastore::tools;
 namespace nmdu = netmeld::datastore::utils;
 
-namespace nmes = netmeld::export_scans;
+namespace nmdes = netmeld::datastore::exporters::scans;
 
 
 // =============================================================================
@@ -86,42 +87,56 @@ class Tool : public nmdt::AbstractExportTool
     addToolOptions() override
     {
       opts.addRequiredOption("out-format", std::make_tuple(
-            "out-format",
-            po::value<std::string>()->default_value("context"),
-            "Export data to the specified format (context|csv)")
-          );
+            "out-format"
+          , po::value<std::string>()->default_value("context")
+          , "Export data to the specified format (context|csv)"
+          )
+        );
 
       opts.addOptionalOption("intra-network", std::make_tuple(
-            "intra-network",
-            NULL_SEMANTIC,
-            "Export Playbook intra-network scan information")
-          );
+           "intra-network"
+          , NULL_SEMANTIC
+          , "Export Playbook intra-network scan information"
+          )
+        );
       opts.addOptionalOption("inter-network", std::make_tuple(
-            "inter-network",
-            NULL_SEMANTIC,
-            "Export Playbook inter-network scan information")
-          );
+            "inter-network"
+          , NULL_SEMANTIC
+          , "Export Playbook inter-network scan information"
+          )
+        );
       opts.addOptionalOption("nessus", std::make_tuple(
-            "nessus",
-            NULL_SEMANTIC,
-            "Export Nessus scan information")
-          );
+            "nessus"
+          , NULL_SEMANTIC
+          , "Export Nessus scan information"
+          )
+        );
       opts.addOptionalOption("prowler", std::make_tuple(
-            "prowler",
-            NULL_SEMANTIC,
-            "Export Prowler scan information")
-          );
+            "prowler"
+          , NULL_SEMANTIC
+          , "Export Prowler scan information"
+          )
+        );
       opts.addOptionalOption("ssh", std::make_tuple(
-            "ssh",
-            NULL_SEMANTIC,
-            "Export SSH algorithm scan information")
-          );
+            "ssh"
+          , NULL_SEMANTIC
+          , "Export SSH algorithm scan information"
+          )
+        );
 
       opts.addOptionalOption("to-file", std::make_tuple(
-            "to-file",
-            NULL_SEMANTIC,
-            "Output to file (predefined naming) instead of STDOUT")
-          );
+            "to-file"
+          , NULL_SEMANTIC
+          , "Output to file (predefined naming) instead of STDOUT"
+          )
+        );
+
+      opts.addOptionalOption("template", std::make_tuple(
+            "template"
+          , NULL_SEMANTIC
+          , "Output template rather than actual data"
+          )
+        );
     }
 
     // Overriden from AbstractExportTool
@@ -130,41 +145,52 @@ class Tool : public nmdt::AbstractExportTool
     {
       const auto& dbConInfo {getDbConnectString()};
 
-      const auto& toFile    {opts.exists("to-file")};
-      const auto& outFormat {nmcu::toLower(opts.getValue("out-format"))};
+      const auto& toFile      {opts.exists("to-file")};
+      const auto& outFormat   {nmcu::toLower(opts.getValue("out-format"))};
 
-      std::unique_ptr<Writer> writer;
+      std::unique_ptr<nmdes::Writer> writer;
       if ("context" == outFormat) {
-        writer = std::make_unique<nmes::Context>(toFile);
+        writer = std::make_unique<nmdes::Context>(toFile);
       } else if ("csv" == outFormat) {
-        writer = std::make_unique<nmes::Csv>(toFile);
+        writer = std::make_unique<nmdes::Csv>(toFile);
       } else {
         LOG_ERROR << "Invalid output format, quitting." << std::endl;
         return nmcu::Exit::FAILURE;
       }
 
       if (opts.exists("intra-network")) {
-        nmes::IntraNetwork exporter {dbConInfo};
-        exporter.exportScan(writer);
+        nmdes::IntraNetwork exporter {dbConInfo};
+        doExport(exporter, writer);
       }
       if (opts.exists("inter-network")) {
-        nmes::InterNetwork exporter {dbConInfo};
-        exporter.exportScan(writer);
+        nmdes::InterNetwork exporter {dbConInfo};
+        doExport(exporter, writer);
       }
       if (opts.exists("nessus")) {
-        nmes::Nessus exporter {dbConInfo};
-        exporter.exportScan(writer);
+        nmdes::Nessus exporter {dbConInfo};
+        doExport(exporter, writer);
       }
       if (opts.exists("prowler")) {
-        nmes::Prowler exporter {dbConInfo};
-        exporter.exportScan(writer);
+        nmdes::Prowler exporter {dbConInfo};
+        doExport(exporter, writer);
       }
       if (opts.exists("ssh")) {
-        nmes::SshAlgorithms exporter {dbConInfo};
-        exporter.exportScan(writer);
+        nmdes::SshAlgorithms exporter {dbConInfo};
+        doExport(exporter, writer);
       }
 
       return nmcu::Exit::SUCCESS;
+    }
+
+    void
+    doExport(auto& exporter, auto& writer) {
+      if (opts.exists("template")) {
+        LOG_DEBUG << "Exporting template data\n";        
+        exporter.exportTemplate(writer);
+      } else {
+        LOG_DEBUG << "Exporting DB data\n";
+        exporter.exportFromDb(writer);
+      }
     }
 
   protected: // Methods part of subclass API

--- a/datastore/exporters/nmdb-export-scans/writers/Context.hpp
+++ b/datastore/exporters/nmdb-export-scans/writers/Context.hpp
@@ -1,5 +1,5 @@
 // =============================================================================
-// Copyright 2022 National Technology & Engineering Solutions of Sandia, LLC
+// Copyright 2023 National Technology & Engineering Solutions of Sandia, LLC
 // (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
 // Government retains certain rights in this software.
 //
@@ -29,7 +29,7 @@
 
 #include "Writer.hpp"
 
-namespace netmeld::export_scans {
+namespace netmeld::datastore::exporters::scans {
   // ==========================================================================
   // Primary object
   // ==========================================================================
@@ -56,6 +56,7 @@ namespace netmeld::export_scans {
     private: // Methods which should be hidden from API users
     protected: // Methods part of subclass API
       std::string getExtension() const override;
+      std::string escapeSpecial(const std::string&) const;
 
     public: // Methods part of public API
       std::string getInterNetwork(const std::string&) const override;
@@ -74,32 +75,34 @@ namespace netmeld::export_scans {
       void codeTableClose(auto&) const; // generic close a ConTeXt table
 
       void codeTableIntra(auto&, const auto&) const;
-      void codeRowIntra(auto&,
-          const auto&, const auto&, const auto&, const auto&, const auto&,
-          const auto&, const auto&
+      void codeRowIntra(auto&
+        , const auto&, const auto&, const auto&, const auto&, const auto&
+        , const auto&, const auto&
         ) const;
 
       void codeTableInter(auto&, const auto&) const;
-      void codeRowInter(auto&,
-          const auto&, const auto&, const auto&, const auto&, const auto&,
-          const auto&, const auto&
+      void codeRowInter(auto&
+        , const auto&, const auto&, const auto&, const auto&, const auto&
+        , const auto&, const auto&
         ) const;
 
-      void codeParagraphNessus(auto&,
-          const auto&, const auto&, const auto&, const auto&
+      void codeParagraphNessus(auto&
+        , const auto&, const auto&, const auto&, const auto&
         ) const;
 
-      void codeSectionProwler(auto&, const auto&) const;
-      void codeSubsectionProwler(auto&,
-          const auto&, const auto&, const auto&, const auto&, const auto&,
-          const auto&, const auto&, const auto&
+      void codeChapterProwler(auto&) const;
+      void codeSectionProwler(auto&, const auto&, const auto&) const;
+      void codeSubSectionProwler(auto&, const auto&, const auto&) const;
+      void codeSubSubSectionProwler(auto&
+        , const auto&, const auto&, const auto&, const auto&
+        , const auto&, const auto&, const auto&, const auto&
         ) const;
 
 
       void codeTableSsh(auto&) const;
-      void codeRowSsh(auto&,
-          const auto&, const auto&, const auto&, const auto&, const auto&,
-          const auto&, const auto&, const auto&
+      void codeRowSsh(auto&
+        , const auto&, const auto&, const auto&, const auto&, const auto&
+        , const auto&, const auto&, const auto&
         ) const;
   };
 }

--- a/datastore/exporters/nmdb-export-scans/writers/Csv.cpp
+++ b/datastore/exporters/nmdb-export-scans/writers/Csv.cpp
@@ -29,7 +29,7 @@
 
 #include "Csv.hpp"
 
-namespace netmeld::export_scans {
+namespace netmeld::datastore::exporters::scans {
   // ==========================================================================
   // Constructors
   // ==========================================================================
@@ -158,14 +158,18 @@ namespace netmeld::export_scans {
     std::ostringstream oss(std::ios_base::binary | std::ios_base::trunc);
 
     // add column headers
-    oss << R"("Service",)"
+    size_t colCount {12};
+    oss << R"("Provider",)"
+        << R"("Account ID",)"
+        << R"("Service Name",)"
+        << R"("Sub-Service Name",)"
         << R"("Severity",)"
-        << R"("Control ID",)"
-        << R"("Level",)"
-        << R"("Control",)"
+        << R"("Check ID",)"
+        << R"("Description",)"
         << R"("Risk",)"
-        << R"("Remediation",)"
-        << R"("Documentation Link",)"
+        << R"("Recommendation",)"
+        << R"("URL",)"
+        << R"("Code",)"
         << R"("Affected Resources")"
         << '\n'
         ;
@@ -173,12 +177,12 @@ namespace netmeld::export_scans {
     // add table rows
     for (const auto& row : rows) {
       size_t count {row.size()};
-      for (size_t i {0}; i < 8; i++) {
+      for (size_t i {0}; i < colCount; i++) {
         auto ccol {replaceAll(row[i], "\"", "\\\"")};
         oss << '"' << ccol << '"' << ',';
       }
       oss << '"';
-      for (size_t i {8}; i < count;) {
+      for (size_t i {colCount}; i < count;) {
         oss << row[i];
         i++;
 

--- a/datastore/exporters/nmdb-export-scans/writers/Csv.hpp
+++ b/datastore/exporters/nmdb-export-scans/writers/Csv.hpp
@@ -29,7 +29,7 @@
 
 #include "Writer.hpp"
 
-namespace netmeld::export_scans {
+namespace netmeld::datastore::exporters::scans {
   // ==========================================================================
   // Primary object
   // ==========================================================================

--- a/datastore/exporters/nmdb-export-scans/writers/Writer.cpp
+++ b/datastore/exporters/nmdb-export-scans/writers/Writer.cpp
@@ -29,67 +29,67 @@
 #include <fstream>
 #include <sstream>
 
-#include <netmeld/core/utils/LoggerSingleton.hpp>
-
 #include "Writer.hpp"
 
-// =============================================================================
-// Constructors
-// =============================================================================
-Writer::Writer(bool _toFile) :
-  toFile(_toFile)
-{}
+namespace netmeld::datastore::exporters::scans {
+  // ===========================================================================
+  // Constructors
+  // ===========================================================================
+  Writer::Writer(bool _toFile) :
+    toFile(_toFile)
+  {}
 
 
-// =============================================================================
-// Methods
-// =============================================================================
-void
-Writer::addRow(const std::vector<std::string>& _row)
-{
-  rows.push_back(_row);
-}
-
-void
-Writer::clearData()
-{
-  rows.clear();
-}
-
-std::string
-Writer::replaceAll(
-    const std::string& source, const std::string& from, const std::string& to
-  ) const
-{
-  std::string str {source};
-  for (auto pos {str.find(from)};
-       pos != std::string::npos;
-       pos = str.find(from, pos))
+  // ===========================================================================
+  // Methods
+  // ===========================================================================
+  void
+  Writer::addRow(const std::vector<std::string>& _row)
   {
-    str.replace(pos, from.length(), to);
-    pos += to.length();
+    rows.push_back(_row);
   }
 
-  return str;
-}
+  void
+  Writer::clearData()
+  {
+    rows.clear();
+  }
 
-void
-Writer::writeData(const std::string& filename, const std::string& data) const
-{
-  std::regex bs {"/"};
-  auto fullFilename {
-    std::regex_replace(filename, bs, "_") + getExtension()
-  };
+  std::string
+  Writer::replaceAll(
+      const std::string& source, const std::string& from, const std::string& to
+    ) const
+  {
+    std::string str {source};
+    for (auto pos {str.find(from)};
+         pos != std::string::npos;
+         pos = str.find(from, pos))
+    {
+      str.replace(pos, from.length(), to);
+      pos += to.length();
+    }
 
-  if (toFile) {
-    LOG_INFO << "Writing to file: " << fullFilename << std::endl;
-    std::ofstream ofs
-      {fullFilename, std::ios_base::binary | std::ios_base::trunc};
+    return str;
+  }
 
-    ofs << data << std::endl;
-    ofs.close();
-  } else {
-    LOG_INFO << "---START OF " << fullFilename << "---" << std::endl
-             << data << std::endl;
+  void
+  Writer::writeData(const std::string& filename, const std::string& data) const
+  {
+    std::regex bs {"/"};
+    auto fullFilename {
+      std::regex_replace(filename, bs, "_") + getExtension()
+    };
+
+    if (toFile) {
+      LOG_INFO << "Writing to file: " << fullFilename << std::endl;
+      std::ofstream ofs
+        {fullFilename, std::ios_base::binary | std::ios_base::trunc};
+
+      ofs << data << std::endl;
+      ofs.close();
+    } else {
+      LOG_INFO << "---START OF " << fullFilename << "---" << std::endl
+               << data << std::endl;
+    }
   }
 }

--- a/datastore/exporters/nmdb-export-scans/writers/Writer.hpp
+++ b/datastore/exporters/nmdb-export-scans/writers/Writer.hpp
@@ -1,5 +1,5 @@
 // =============================================================================
-// Copyright 2022 National Technology & Engineering Solutions of Sandia, LLC
+// Copyright 2023 National Technology & Engineering Solutions of Sandia, LLC
 // (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
 // Government retains certain rights in this software.
 //
@@ -30,53 +30,56 @@
 #include <string>
 #include <vector>
 
-// =============================================================================
-// Primary object
-// =============================================================================
-class Writer {
-  // =========================================================================
-  // Variables
-  // =========================================================================
-  private: // Variables should generally be private
-  protected: // Variables intended for internal/subclass API
-    bool toFile {false};
+#include <netmeld/core/utils/LoggerSingleton.hpp>
 
-    std::vector<std::vector<std::string>> rows;
+namespace netmeld::datastore::exporters::scans {
+  // ===========================================================================
+  // Primary object
+  // ===========================================================================
+  class Writer {
+    // =========================================================================
+    // Variables
+    // =========================================================================
+    private: // Variables should generally be private
+    protected: // Variables intended for internal/subclass API
+      bool toFile {false};
 
-  public: // Variables should rarely appear at this scope
+      std::vector<std::vector<std::string>> rows;
 
-  // =========================================================================
-  // Constructors
-  // =========================================================================
-  private: // Constructors which should be hidden from API users
-  protected: // Constructors part of subclass API
-  public: // Constructors part of public API
-    Writer() = delete;
-    Writer(bool);
-    virtual ~Writer() = default;
+    public: // Variables should rarely appear at this scope
 
-  // =========================================================================
-  // Methods
-  // =========================================================================
-  private: // Methods which should be hidden from API users
-  protected: // Methods part of subclass API
-    std::string replaceAll(
-        const std::string&, const std::string&, const std::string&
-      ) const;
+    // =========================================================================
+    // Constructors
+    // =========================================================================
+    private: // Constructors which should be hidden from API users
+    protected: // Constructors part of subclass API
+    public: // Constructors part of public API
+      Writer() = delete;
+      Writer(bool);
+      virtual ~Writer() = default;
 
-    virtual std::string getExtension() const = 0;
+    // =========================================================================
+    // Methods
+    // =========================================================================
+    private: // Methods which should be hidden from API users
+    protected: // Methods part of subclass API
+      std::string replaceAll(
+          const std::string&, const std::string&, const std::string&
+        ) const;
 
-  public: // Methods part of public API
-    virtual void addRow(const std::vector<std::string>&);
-    virtual void clearData();
+      virtual std::string getExtension() const = 0;
 
-    virtual void writeData(const std::string&, const std::string&) const;
+    public: // Methods part of public API
+      virtual void addRow(const std::vector<std::string>&);
+      virtual void clearData();
 
-    virtual std::string getIntraNetwork(const std::string&) const = 0;
-    virtual std::string getInterNetwork(const std::string&) const = 0;
-    virtual std::string getNessus() const = 0;
-    virtual std::string getProwler() const = 0;
-    virtual std::string getSshAlgorithms() const = 0;
-};
+      virtual void writeData(const std::string&, const std::string&) const;
 
+      virtual std::string getIntraNetwork(const std::string&) const = 0;
+      virtual std::string getInterNetwork(const std::string&) const = 0;
+      virtual std::string getNessus() const = 0;
+      virtual std::string getProwler() const = 0;
+      virtual std::string getSshAlgorithms() const = 0;
+  };
+}
 #endif // WRITER_HPP

--- a/datastore/importers/nmdb-import-prowler/CMakeLists.txt
+++ b/datastore/importers/nmdb-import-prowler/CMakeLists.txt
@@ -26,7 +26,8 @@
 
 add_executable(${TGT_TOOL}
     Parser.cpp
-    ProwlerData.cpp
+    ProwlerV2Data.cpp
+    ProwlerV3Data.cpp
     ${TGT_TOOL}.cpp
   )
 

--- a/datastore/importers/nmdb-import-prowler/Parser.cpp
+++ b/datastore/importers/nmdb-import-prowler/Parser.cpp
@@ -41,29 +41,32 @@ void
 Parser::fromJsonV2(std::ifstream& _file)
 {
   // V2 output is a JSON lines file
+  Data d;
   std::string line;
   while (std::getline(_file, line)) {
-    json jline;
-    jline = json::parse(line);
-
-    Data d {jline};
-    if (d != Data()) {
-      r.emplace_back(d);
+    json jline = json::parse(line);
+    nmdop::ProwlerV2Data v2d {jline};
+    if (v2d != nmdop::ProwlerV2Data()) {
+      d.v2Data.push_back(v2d);
     }
   }
+  r.push_back(d);
 }
 
 void
 Parser::fromJsonV3(std::ifstream& _file)
 {
   // V3 output is a JSON array
+  Data d;
   auto dataArray = json::parse(_file);
   for (const auto& entry : dataArray) {
-    Data d {entry};
-    if (d != Data()) {
-      r.emplace_back(d);
+    LOG_DEBUG << "P1" << std::endl;
+    nmdop::ProwlerV3Data v3d {entry};
+    if (v3d != nmdop::ProwlerV3Data()) {
+      d.v3Data.push_back(v3d);
     }
   }
+  r.push_back(d);
 }
 
 

--- a/datastore/importers/nmdb-import-prowler/Parser.cpp
+++ b/datastore/importers/nmdb-import-prowler/Parser.cpp
@@ -25,6 +25,7 @@
 // =============================================================================
 
 #include <nlohmann/json.hpp>
+#include <string>
 
 #include "Parser.hpp"
 
@@ -37,9 +38,11 @@ Parser::Parser()
 {}
 
 void
-Parser::parseJsonLine(const std::string_view line)
+Parser::fromJsonV2(std::ifstream& _file)
 {
-  try {
+  // V2 output is a JSON lines file
+  std::string line;
+  while (std::getline(_file, line)) {
     json jline;
     jline = json::parse(line);
 
@@ -47,11 +50,22 @@ Parser::parseJsonLine(const std::string_view line)
     if (d != Data()) {
       r.emplace_back(d);
     }
-  } catch (json::parse_error& ex) {
-    LOG_WARN << "Parse error at byte " << ex.byte
-             << " for line -- " << line << std::endl;
   }
 }
+
+void
+Parser::fromJsonV3(std::ifstream& _file)
+{
+  // V3 output is a JSON array
+  auto dataArray = json::parse(_file);
+  for (const auto& entry : dataArray) {
+    Data d {entry};
+    if (d != Data()) {
+      r.emplace_back(d);
+    }
+  }
+}
+
 
 
 // =============================================================================

--- a/datastore/importers/nmdb-import-prowler/Parser.hpp
+++ b/datastore/importers/nmdb-import-prowler/Parser.hpp
@@ -1,5 +1,5 @@
 // =============================================================================
-// Copyright 2022 National Technology & Engineering Solutions of Sandia, LLC
+// Copyright 2023 National Technology & Engineering Solutions of Sandia, LLC
 // (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
 // Government retains certain rights in this software.
 //
@@ -26,6 +26,8 @@
 
 #ifndef PARSER_HPP
 #define PARSER_HPP
+
+#include <fstream>
 
 #include "ProwlerData.hpp"
 
@@ -61,7 +63,8 @@ class Parser
   // ===========================================================================
   private:
   public:
-    void parseJsonLine(const std::string_view);
+    void fromJsonV2(std::ifstream&);
+    void fromJsonV3(std::ifstream&);
     Result getData();
 };
 #endif // PARSER_HPP

--- a/datastore/importers/nmdb-import-prowler/Parser.hpp
+++ b/datastore/importers/nmdb-import-prowler/Parser.hpp
@@ -29,15 +29,22 @@
 
 #include <fstream>
 
-#include "ProwlerData.hpp"
+#include "ProwlerV2Data.hpp"
+#include "ProwlerV3Data.hpp"
 
-namespace nmdo = netmeld::datastore::objects;
+namespace nmdop = netmeld::datastore::objects::prowler;
 
 
 // =============================================================================
 // Data containers
 // =============================================================================
-typedef nmdo::ProwlerData  Data;
+struct Data {
+  std::vector<nmdop::ProwlerV2Data> v2Data;
+  std::vector<nmdop::ProwlerV3Data> v3Data;
+
+  auto operator<=>(const Data&) const = default;
+  bool operator==(const Data&) const = default;
+};
 typedef std::vector<Data>  Result;
 
 

--- a/datastore/importers/nmdb-import-prowler/ProwlerV2Data.cpp
+++ b/datastore/importers/nmdb-import-prowler/ProwlerV2Data.cpp
@@ -111,18 +111,18 @@ namespace netmeld::datastore::objects::prowler {
 
     oss << R"([)"
         << R"("accountNumber": ")" << accountNumber
-        << R"(", timestamp": ")" << timestamp
-        << R"(", region": ")" << region
-        << R"(", control": ")" << control
-        << R"(", severity": ")" << severity
-        << R"(", status": ")" << status
-        << R"(", level": ")" << level
-        << R"(", controlId": ")" << controlId
-        << R"(", service": ")" << service
-        << R"(", risk": ")" << risk
-        << R"(", remediation": ")" << remediation
-        << R"(", documentationLink": ")" << documentationLink
-        << R"(", resourceId": ")" << resourceId
+        << R"(", "timestamp": ")" << timestamp
+        << R"(", "region": ")" << region
+        << R"(", "control": ")" << control
+        << R"(", "severity": ")" << severity
+        << R"(", "status": ")" << status
+        << R"(", "level": ")" << level
+        << R"(", "controlId": ")" << controlId
+        << R"(", "service": ")" << service
+        << R"(", "risk": ")" << risk
+        << R"(", "remediation": ")" << remediation
+        << R"(", "documentationLink": ")" << documentationLink
+        << R"(", "resourceId": ")" << resourceId
         << R"("])"
       ;
 

--- a/datastore/importers/nmdb-import-prowler/ProwlerV2Data.cpp
+++ b/datastore/importers/nmdb-import-prowler/ProwlerV2Data.cpp
@@ -109,7 +109,7 @@ namespace netmeld::datastore::objects::prowler {
   {
     std::ostringstream oss;
 
-    oss << "["
+    oss << R"([)"
         << R"("accountNumber": ")" << accountNumber
         << R"(", timestamp": ")" << timestamp
         << R"(", region": ")" << region
@@ -123,7 +123,7 @@ namespace netmeld::datastore::objects::prowler {
         << R"(", remediation": ")" << remediation
         << R"(", documentationLink": ")" << documentationLink
         << R"(", resourceId": ")" << resourceId
-        << "]"
+        << R"("])"
       ;
 
     return oss.str();

--- a/datastore/importers/nmdb-import-prowler/ProwlerV2Data.cpp
+++ b/datastore/importers/nmdb-import-prowler/ProwlerV2Data.cpp
@@ -24,59 +24,34 @@
 // Maintained by Sandia National Laboratories <Netmeld@sandia.gov>
 // =============================================================================
 
-#include "ProwlerData.hpp"
+#include "ProwlerV2Data.hpp"
 
 #include <netmeld/core/utils/StringUtilities.hpp>
 
 namespace nmcu = netmeld::core::utils;
 
 
-namespace netmeld::datastore::objects {
+namespace netmeld::datastore::objects::prowler {
 
   // ===========================================================================
   // Constructors
   // ===========================================================================
-  ProwlerData::ProwlerData(const json& jline)
+  /* V2 -- {"Profile":"","Account Number":"","Control":"","Message":"","Severity":"","Status":"","Scored":"","Level":"","Control ID":"","Region":"","Timestamp":"","Compliance":"","Service":"","CAF Epic":"","Risk":"","Remediation":"","Doc link":"","Resource ID":"","Account Email":"","Account Name":"","Account ARN":"","Account Organization":"","Account tags":""} */
+  ProwlerV2Data::ProwlerV2Data(const json& jline)
   {
-    // TODO differences between v2 and v3 are significant enough that the
-    // DB needs to be modified and validation checks updated
-
-    bool isV2 {jline.contains("Account Number")};
-
-    switch(isV2) {
-      case true:
-        /* V2 -- {"Profile":"","Account Number":"","Control":"","Message":"","Severity":"","Status":"","Scored":"","Level":"","Control ID":"","Region":"","Timestamp":"","Compliance":"","Service":"","CAF Epic":"","Risk":"","Remediation":"","Doc link":"","Resource ID":"","Account Email":"","Account Name":"","Account ARN":"","Account Organization":"","Account tags":""} */
-        accountNumber = jline["Account Number"];
-        region = jline["Region"];
-        control = jline["Control"];
-        severity = nmcu::toLower(jline["Severity"]);
-        status = jline["Status"];
-        level = jline["Level"];
-        controlId = jline["Control ID"];
-        service = jline["Service"];
-        risk = jline["Risk"];
-        remediation = jline["Remediation"];
-        documentationLink = jline["Doc link"];
-        resourceId = jline["Resource ID"];
-        timestamp.readFormatted(jline["Timestamp"], "%Y-%m-%dT%H:%M:%SZ"); // 2022-01-01T01:01:01Z
-        break;
-      case false:
-        /* V3 -- {"AssessmentStartTime":"", "FindingUniqueId": "", "Provider": "", "Profile": "", "AccountId": "", "OrganizationsInfo": "", "Region": "", "CheckID": "", "CheckTitle": "", "CheckType": [], "ServiceName": "", "SubServiceName": "", "Status": "", "StatusExtended": "", "Severity": "", "ResourceId": "", "ResourceArn": "", "ResourceTags": {}, "ResourceType": "", "ResourceDetails": "", "Description": "", "Risk": "", "RelatedUrl": "", "Remediation": { "Code": { "NativeIaC": "", "Terraform": "", "CLI": "", "Other": "" }, "Recommendation": { "Text": "", "Url": "" } }, "Categories": [], "Notes": "", "Compliance": {} */
-        accountNumber = jline["AccountId"];
-        region = jline["Region"];
-        control = jline["CheckTitle"];
-        severity = jline["Severity"];
-        status = jline["Status"];
-//        level = jline[""];
-        controlId = jline["CheckID"];
-        service = jline["ServiceName"];
-        risk = jline["Risk"];
-        remediation = jline["Remediation"]["Recommendation"]["Text"];
-        documentationLink = jline["Remediation"]["Recommendation"]["Url"];
-        resourceId = jline["ResourceId"];
-        timestamp.readFormatted(jline["AssessmentStartTime"], "%Y-%m-%dT%H:%M:%S"); // 2022-01-01T01:01:01
-        break;
-    }
+    accountNumber = jline["Account Number"];
+    region = jline["Region"];
+    control = jline["Control"];
+    severity = nmcu::toLower(jline["Severity"]);
+    status = jline["Status"];
+    level = jline["Level"];
+    controlId = jline["Control ID"];
+    service = jline["Service"];
+    risk = jline["Risk"];
+    remediation = jline["Remediation"];
+    documentationLink = jline["Doc link"];
+    resourceId = jline["Resource ID"];
+    timestamp.readFormatted(jline["Timestamp"], "%Y-%m-%dT%H:%M:%SZ"); // 2022-01-01T01:01:01Z
   }
 
   // ===========================================================================
@@ -84,24 +59,25 @@ namespace netmeld::datastore::objects {
   // ===========================================================================
 
   bool
-  ProwlerData::isValid() const
+  ProwlerV2Data::isValid() const
   {
+    // v2: accountNumber-timestamp-region-level-controlid-service
     return !(
            accountNumber.empty()
-//        || timestamp.isNull()
-//        || region.empty()
-//        || level.empty()
-//        || controlId.empty()
-//        || service.empty()
+        || timestamp.isNull()
+        || region.empty()
+        || level.empty()
+        || controlId.empty()
+        || service.empty()
       );
   }
 
   void
-  ProwlerData::save(pqxx::transaction_base& t,
+  ProwlerV2Data::save(pqxx::transaction_base& t,
                          const nmco::Uuid& toolRunId, const std::string&)
   {
     if (!isValid()) {
-      LOG_DEBUG << "ProwlerData object is not saving: " << toDebugString()
+      LOG_DEBUG << "ProwlerV2Data object is not saving: " << toDebugString()
                 << std::endl;
       return; // Always short circuit if invalid object
     }
@@ -110,7 +86,7 @@ namespace netmeld::datastore::objects {
     //         accountNumber, timestamp, region, level, controlId, service,
     //         resourceId
     //       However, resourceId can be NULL so problematic for the DB
-    t.exec_prepared("insert_raw_prowler_check",
+    t.exec_prepared("insert_raw_prowler_v2_check",
           toolRunId
         , accountNumber
         , timestamp
@@ -129,33 +105,32 @@ namespace netmeld::datastore::objects {
   }
 
   std::string
-  ProwlerData::toDebugString() const
+  ProwlerV2Data::toDebugString() const
   {
     std::ostringstream oss;
 
-    oss << "["; // opening bracket
-
-    oss << R"("accountNumber": ")" << accountNumber << R"(", )";
-    oss << R"("timestamp": ")" << timestamp << R"(", )";
-    oss << R"("region": ")" << region << R"(", )";
-    oss << R"("control": ")" << control << R"(", )";
-    oss << R"("severity": ")" << severity << R"(", )";
-    oss << R"("status": ")" << status << R"(", )";
-    oss << R"("level": ")" << level << R"(", )";
-    oss << R"("controlId": ")" << controlId << R"(", )";
-    oss << R"("service": ")" << service << R"(", )";
-    oss << R"("risk": ")" << risk << R"(", )";
-    oss << R"("remediation": ")" << remediation << R"(", )";
-    oss << R"("documentationLink": ")" << documentationLink << R"(", )";
-    oss << R"("resourceId": ")" << resourceId << R"(")";
-
-    oss << "]"; // closing bracket
+    oss << "["
+        << R"("accountNumber": ")" << accountNumber
+        << R"(", timestamp": ")" << timestamp
+        << R"(", region": ")" << region
+        << R"(", control": ")" << control
+        << R"(", severity": ")" << severity
+        << R"(", status": ")" << status
+        << R"(", level": ")" << level
+        << R"(", controlId": ")" << controlId
+        << R"(", service": ")" << service
+        << R"(", risk": ")" << risk
+        << R"(", remediation": ")" << remediation
+        << R"(", documentationLink": ")" << documentationLink
+        << R"(", resourceId": ")" << resourceId
+        << "]"
+      ;
 
     return oss.str();
   }
 
   std::strong_ordering
-  ProwlerData::operator<=>(const ProwlerData& rhs) const
+  ProwlerV2Data::operator<=>(const ProwlerV2Data& rhs) const
   {
     return std::tie( accountNumber
                    , timestamp
@@ -189,7 +164,7 @@ namespace netmeld::datastore::objects {
   }
 
   bool
-  ProwlerData::operator==(const ProwlerData& rhs) const
+  ProwlerV2Data::operator==(const ProwlerV2Data& rhs) const
   {
     return 0 == operator<=>(rhs);
   }

--- a/datastore/importers/nmdb-import-prowler/ProwlerV2Data.hpp
+++ b/datastore/importers/nmdb-import-prowler/ProwlerV2Data.hpp
@@ -24,8 +24,8 @@
 // Maintained by Sandia National Laboratories <Netmeld@sandia.gov>
 // =============================================================================
 
-#ifndef PROWLER_DATA_HPP
-#define PROWLER_DATA_HPP
+#ifndef PROWLER_V2_DATA_HPP
+#define PROWLER_V2_DATA_HPP
 
 #include <set>
 #include <nlohmann/json.hpp>
@@ -36,9 +36,9 @@
 using json = nlohmann::json;
 namespace nmco = netmeld::core::objects;
 
-namespace netmeld::datastore::objects {
+namespace netmeld::datastore::objects::prowler {
 
-  class ProwlerData : public AbstractDatastoreObject {
+  class ProwlerV2Data : public AbstractDatastoreObject {
     // =========================================================================
     // Variables
     // =========================================================================
@@ -66,8 +66,8 @@ namespace netmeld::datastore::objects {
     private: // Constructors which should be hidden from API users
     protected: // Constructors part of subclass API
     public: // Constructors part of public API
-      ProwlerData() = default;
-      explicit ProwlerData(const json&);
+      ProwlerV2Data() = default;
+      explicit ProwlerV2Data(const json&);
 
     // =========================================================================
     // Methods
@@ -82,8 +82,8 @@ namespace netmeld::datastore::objects {
       // Utilized for full object data dump, for debug purposes
       std::string toDebugString() const override;
 
-      std::strong_ordering operator<=>(const ProwlerData&) const;
-      bool operator==(const ProwlerData&) const;
+      std::strong_ordering operator<=>(const ProwlerV2Data&) const;
+      bool operator==(const ProwlerV2Data&) const;
   };
 }
-#endif // PROWLER_DATA_HPP
+#endif // PROWLER_V2_DATA_HPP

--- a/datastore/importers/nmdb-import-prowler/ProwlerV3Data.cpp
+++ b/datastore/importers/nmdb-import-prowler/ProwlerV3Data.cpp
@@ -1,0 +1,326 @@
+// =============================================================================
+// Copyright 2023 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// =============================================================================
+// Maintained by Sandia National Laboratories <Netmeld@sandia.gov>
+// =============================================================================
+
+#include "ProwlerV3Data.hpp"
+
+#include <format>
+
+#include <netmeld/core/utils/StringUtilities.hpp>
+
+namespace nmcu = netmeld::core::utils;
+
+
+namespace netmeld::datastore::objects::prowler {
+
+  // ===========================================================================
+  // Constructors
+  // ===========================================================================
+  /* V3 -- {
+      "AssessmentStartTime":"", "FindingUniqueId": "", "Provider": ""
+    , "Profile": "", "AccountId": "", "OrganizationsInfo": [], "Region": ""
+    , "CheckID": "", "CheckTitle": "", "CheckType": [], "ServiceName": ""
+    , "SubServiceName": "", "Status": "", "StatusExtended": "", "Severity": ""
+    , "ResourceId": "", "ResourceArn": "", "ResourceTags": {}
+    , "ResourceType": "", "ResourceDetails": "", "Description": "", "Risk": ""
+    , "RelatedUrl": "" , "Remediation": {
+      "Code": { "NativeIaC": "", "Terraform": "", "CLI": "", "Other": "" }
+      , "Recommendation": { "Text": "", "Url": "" }
+    }, "Categories": [] , "Notes": "", "Compliance": {}
+  */
+  ProwlerV3Data::ProwlerV3Data(const json& jline)
+  {
+    // string values
+    assessmentStartTime.readFormatted(jline.value("AssessmentStartTime", "")
+                                     , "%Y-%m-%dT%H:%M:%S");
+    findingUniqueId = jline.value("FindingUniqueId", "");
+    provider = jline.value("Provider", "");
+    profile = jline.value("Profile", "");
+    accountId = jline.value("AccountId", "");
+    region = jline.value("Region", "");
+    checkId = jline.value("CheckID", "");
+    checkTitle = jline.value("CheckTitle", "");
+    serviceName = jline.value("ServiceName", "");
+    subServiceName = jline.value("SubServiceName", "");
+    status = jline.value("Status", "");
+    statusExtended = jline.value("StatusExtended", "");
+    severity = jline.value("Severity", "");
+    resourceId = jline.value("ResourceId", "");
+    resourceArn = jline.value("ResourceArn", "");
+    resourceType = jline.value("ResourceType", "");
+    resourceDetails = jline.value("ResourceDetails", "");
+    description = jline.value("Description", "");
+    risk = jline.value("Risk", "");
+    relatedUrl = jline.value("RelatedUrl", "");
+    notes = jline.value("Notes", "");
+
+    // array values
+    if (jline.contains("CheckType")) {
+      std::vector<std::string> temp;
+      for (const auto& value : jline["CheckType"]) {
+        if (static_cast<std::string>(value).empty()) {continue;}
+        temp.push_back(value);
+      }
+      checkTypes = nmcu::toString(temp, '\n');
+    }
+
+    if (jline.contains("Categories")) {
+      std::vector<std::string> temp;
+      for (const auto& value : jline["Categories"]) {
+        if (static_cast<std::string>(value).empty()) {continue;}
+        temp.push_back(value);
+      }
+      categories = nmcu::toString(temp, '\n');
+    }
+
+    // array of, generally, key/value pairs
+    if (jline.contains("OrganizationsInfo")) {
+      std::vector<std::string> temp;
+      for (const auto& [key, value] : jline["OrganizationsInfo"].items()) {
+        if (static_cast<std::string>(value).empty()) {continue;}
+        std::ostringstream oss;
+        oss << key << ": " << value;
+        temp.push_back(oss.str());
+      }
+      organizationsInfo = nmcu::toString(temp, '\n');
+    }
+
+    if (jline.contains("ResourceTags")) {
+      std::vector<std::string> temp;
+      for (const auto& [key, value] : jline["ResourceTags"].items()) {
+        if (static_cast<std::string>(value).empty()) {continue;}
+        std::ostringstream oss;
+        oss << key << ": " << value;
+        temp.push_back(oss.str());
+      }
+      resourceTags = nmcu::toString(temp, '\n');
+    }
+
+    if (jline.contains("Compliance")) {
+      std::ostringstream oss;
+      std::string sep;
+      for (const auto& [key, values] : jline["Compliance"].items()) {
+        oss << sep << key;
+        for (const auto& value : values) {
+          oss << "\n- " << static_cast<std::string>(value);
+        }
+        sep = '\n';
+      }
+      compliance = oss.str();
+    }
+
+    // more complex constructs
+    if (jline.contains("Remediation")) {
+      const auto& jRemedi = jline["Remediation"];
+      if (jRemedi.contains("Recommendation")) {
+        const auto& jRecom = jRemedi["Recommendation"];
+        recommendation = jRecom.value("Text", "");
+        recommendationUrl = jRecom.value("Url", "");
+      }
+      if (jRemedi.contains("Code")) {
+        std::vector<std::string> temp;
+        for (const auto& [key, value] : jRemedi["Code"].items()) {
+          if (static_cast<std::string>(value).empty()) {continue;}
+          std::ostringstream oss;
+          oss << key << ": " << value;
+          temp.push_back(oss.str());
+        }
+        remediationCode = nmcu::toString(temp, '\n');
+      }
+    }
+  }
+
+  // ===========================================================================
+  // Methods
+  // ===========================================================================
+
+  bool
+  ProwlerV3Data::isValid() const
+  {
+    return !( assessmentStartTime.isNull()
+           || findingUniqueId.empty()
+           )
+      ;
+  }
+
+  void
+  ProwlerV3Data::save(pqxx::transaction_base& t,
+                         const nmco::Uuid& toolRunId, const std::string&)
+  {
+    if (!isValid()) {
+      LOG_DEBUG << "ProwlerV3Data object is not saving: " << toDebugString()
+                << std::endl;
+      return; // Always short circuit if invalid object
+    }
+
+    // NOTE: The following are the suspected minimum for unique:
+    //         timestamp, findingUniqueId
+    t.exec_prepared("insert_raw_prowler_v3_check",
+          toolRunId
+        , assessmentStartTime
+        , findingUniqueId
+        , provider
+        , profile
+        , accountId
+        , organizationsInfo
+        , region
+        , checkId
+        , checkTitle
+        , checkTypes
+        , serviceName
+        , subServiceName
+        , status
+        , statusExtended
+        , severity
+        , resourceId
+        , resourceArn
+        , resourceTags
+        , resourceType
+        , resourceDetails
+        , description
+        , risk
+        , relatedUrl
+        , recommendation
+        , recommendationUrl
+        , remediationCode
+        , categories
+        , notes
+        , compliance
+      );
+  }
+
+  std::string
+  ProwlerV3Data::toDebugString() const
+  {
+    std::ostringstream oss;
+
+    oss << R"([)"
+        << R"("assessmentStartTime": ")" << assessmentStartTime
+        << R"(", "findingUniqueId": ")" << findingUniqueId
+        << R"(", "provider": ")" << provider
+        << R"(", "profile": ")" << profile
+        << R"(", "accountId": ")" << accountId
+        << R"(", "organizationsInfo": ")" << organizationsInfo
+        << R"(", "region": ")" << region
+        << R"(", "checkId": ")" << checkId
+        << R"(", "checkTitle": ")" << checkTitle
+        << R"(", "checkTypes": ")" << checkTypes
+        << R"(", "serviceName": ")" << serviceName
+        << R"(", "subServiceName": ")" << subServiceName
+        << R"(", "status": ")" << status
+        << R"(", "statusExtended": ")" << statusExtended
+        << R"(", "severity": ")" << severity
+        << R"(", "resourceId": ")" << resourceId
+        << R"(", "resourceArn": ")" << resourceArn
+        << R"(", "resourceTags": ")" << resourceTags
+        << R"(", "resourceType": ")" << resourceType
+        << R"(", "resourceDetails": ")" << resourceDetails
+        << R"(", "description": ")" << description
+        << R"(", "risk": ")" << risk
+        << R"(", "relatedUrl": ")" << relatedUrl
+        << R"(", "recommendation": ")" << recommendation
+        << R"(", "recommendationUrl": ")" << recommendationUrl
+        << R"(", "remediationCode": ")" << remediationCode
+        << R"(", "categories": ")" << categories
+        << R"(", "notes": ")" << notes
+        << R"(", "compliance": ")" << compliance
+        << R"("])"
+        ;
+
+    return oss.str();
+  }
+
+  std::strong_ordering
+  ProwlerV3Data::operator<=>(const ProwlerV3Data& rhs) const
+  {
+    return std::tie( assessmentStartTime
+                   , findingUniqueId
+                   , provider
+                   , profile
+                   , accountId
+                   , organizationsInfo
+                   , region
+                   , checkId
+                   , checkTitle
+                   , checkTypes
+                   , serviceName
+                   , subServiceName
+                   , status
+                   , statusExtended
+                   , severity
+                   , resourceId
+                   , resourceArn
+                   , resourceTags
+                   , resourceType
+                   , resourceDetails
+                   , description
+                   , risk
+                   , relatedUrl
+                   , recommendation
+                   , recommendationUrl
+                   , remediationCode
+                   , categories
+                   , notes
+                   , compliance
+                   )
+       <=> std::tie( rhs.assessmentStartTime
+                   , rhs.findingUniqueId
+                   , rhs.provider
+                   , rhs.profile
+                   , rhs.accountId
+                   , rhs.organizationsInfo
+                   , rhs.region
+                   , rhs.checkId
+                   , rhs.checkTitle
+                   , rhs.checkTypes
+                   , rhs.serviceName
+                   , rhs.subServiceName
+                   , rhs.status
+                   , rhs.statusExtended
+                   , rhs.severity
+                   , rhs.resourceId
+                   , rhs.resourceArn
+                   , rhs.resourceTags
+                   , rhs.resourceType
+                   , rhs.resourceDetails
+                   , rhs.description
+                   , rhs.risk
+                   , rhs.relatedUrl
+                   , rhs.recommendation
+                   , rhs.recommendationUrl
+                   , rhs.remediationCode
+                   , rhs.categories
+                   , rhs.notes
+                   , rhs.compliance
+                   )
+      ;
+  }
+
+  bool
+  ProwlerV3Data::operator==(const ProwlerV3Data& rhs) const
+  {
+    return 0 == operator<=>(rhs);
+  }
+}

--- a/datastore/importers/nmdb-import-prowler/ProwlerV3Data.cpp
+++ b/datastore/importers/nmdb-import-prowler/ProwlerV3Data.cpp
@@ -144,7 +144,9 @@ namespace netmeld::datastore::objects::prowler {
         for (const auto& [key, value] : jRemedi["Code"].items()) {
           if (static_cast<std::string>(value).empty()) {continue;}
           std::ostringstream oss;
-          oss << key << ": " << value;
+          oss << std::string(key)
+              << ": " << std::string(value)
+              ;
           temp.push_back(oss.str());
         }
         remediationCode = nmcu::toString(temp, '\n');

--- a/datastore/importers/nmdb-import-prowler/ProwlerV3Data.hpp
+++ b/datastore/importers/nmdb-import-prowler/ProwlerV3Data.hpp
@@ -1,0 +1,105 @@
+// =============================================================================
+// Copyright 2023 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// =============================================================================
+// Maintained by Sandia National Laboratories <Netmeld@sandia.gov>
+// =============================================================================
+
+#ifndef PROWLER_V3_DATA_HPP
+#define PROWLER_V3_DATA_HPP
+
+#include <set>
+#include <nlohmann/json.hpp>
+
+#include <netmeld/core/objects/Time.hpp>
+#include <netmeld/datastore/objects/AbstractDatastoreObject.hpp>
+
+using json = nlohmann::json;
+namespace nmco = netmeld::core::objects;
+
+namespace netmeld::datastore::objects::prowler {
+
+  class ProwlerV3Data : public AbstractDatastoreObject {
+    // =========================================================================
+    // Variables
+    // =========================================================================
+    private: // Variables will probably rarely appear at this scope
+    protected: // Variables intended for internal/subclass API
+      nmco::Time assessmentStartTime;
+      std::string findingUniqueId; // prowler-provider-checkid-accountid-region-resourceid
+      std::string provider;
+      std::string profile;
+      std::string accountId;
+      std::string organizationsInfo;
+      std::string region;
+      std::string checkId;
+      std::string checkTitle;
+      std::string checkTypes;
+      std::string serviceName;
+      std::string subServiceName;
+      std::string status;
+      std::string statusExtended;
+      std::string severity;
+      std::string resourceId;
+      std::string resourceArn;
+      std::string resourceTags;
+      std::string resourceType;
+      std::string resourceDetails;
+      std::string description;
+      std::string risk;
+      std::string relatedUrl;
+      std::string recommendation;
+      std::string recommendationUrl;
+      std::string remediationCode;
+      std::string categories;
+      std::string notes;
+      std::string compliance;
+
+    public: // Variables should rarely appear at this scope
+
+    // =========================================================================
+    // Constructors
+    // =========================================================================
+    private: // Constructors which should be hidden from API users
+    protected: // Constructors part of subclass API
+    public: // Constructors part of public API
+      ProwlerV3Data() = default;
+      explicit ProwlerV3Data(const json&);
+
+    // =========================================================================
+    // Methods
+    // =========================================================================
+    private: // Methods which should be hidden from API users
+    protected: // Methods part of subclass API
+    public: // Methods part of public API
+      bool isValid() const override;
+      void save(pqxx::transaction_base&,
+                const nmco::Uuid&, const std::string&) override;
+
+      // Utilized for full object data dump, for debug purposes
+      std::string toDebugString() const override;
+
+      std::strong_ordering operator<=>(const ProwlerV3Data&) const;
+      bool operator==(const ProwlerV3Data&) const;
+  };
+}
+#endif // PROWLER_V3_DATA_HPP

--- a/datastore/importers/nmdb-import-prowler/README.md
+++ b/datastore/importers/nmdb-import-prowler/README.md
@@ -1,9 +1,10 @@
 DESCRIPTION
 ===========
 
-Parse and import Prowler's JSON output.  You must run Prowler with the `-M
-json` output format option in order to produce the correct JSON format
-(i.e., JSON lines).
+Parse and import Prowler's JSON output.  The format is as if Prowler is ran
+with the `-M json` output format option.  Note that the format between
+Prowler version 2 and 3 changed significantly, thus there is a option for
+this tool to specify which format is being imported.
 
 As the data file can contain information about multiple hosts, this tool
 will not honor usage of the `--device-id` option.  However, the tool still
@@ -13,7 +14,8 @@ allows it to be passed, but ignored, to help facilitate automation.
 EXAMPLES
 ========
 
-Process the target data contained in the file `checks.json`.
+Process the target data contained in the file `checks.json` (defaults to
+Prowler v3 JSON formatting).
 ```
 nmdb-import-prowler checks.json
 ```
@@ -23,7 +25,7 @@ remote host and displays the results locally, then the following would process
 it and save the data to a file called `checks.json` in the current working
 directory.
 ```
-... | nmdb-import-nmap checks.json --pipe
+... | nmdb-import-prowler checks.json --pipe
 ```
 
 See Also: `https://github.com/prowler-cloud/prowler`

--- a/datastore/importers/nmdb-import-prowler/nmdb-import-prowler.cpp
+++ b/datastore/importers/nmdb-import-prowler/nmdb-import-prowler.cpp
@@ -133,9 +133,17 @@ class Tool : public nmdt::AbstractImportTool<P,R>
       const auto& toolRunId {this->getToolRunId()};
       const auto& deviceId  {this->getDeviceId()};
 
-      for (auto& result : this->tResults) {
-        result.save(t, toolRunId, deviceId);
-        LOG_DEBUG << result.toDebugString() << std::endl;
+      for (auto& results : this->tResults) {
+
+        for (auto& entry : results.v2Data) {
+          entry.save(t, toolRunId, deviceId);
+          LOG_DEBUG << entry.toDebugString() << std::endl;
+        }
+
+        for (auto& entry : results.v3Data) {
+          entry.save(t, toolRunId, deviceId);
+          LOG_DEBUG << entry.toDebugString() << std::endl;
+        }
       }
     }
 

--- a/datastore/importers/nmdb-import-rpm-query/README.md
+++ b/datastore/importers/nmdb-import-rpm-query/README.md
@@ -1,7 +1,7 @@
 DESCRIPTION
 ===========
 
-Parse and import the output of the 
+Parse and import the output of the
 `rpm -qa --queryformat="%-50{NAME}%10{VERSION}-%-20{RELEASE}%-20{ARCH}%{SUMMARY}\n"`
 command on modern Linux
 systems into the Netmeld framework for later analysis. Import's package's

--- a/datastore/nmdb-remove-tool-run/nmdb-remove-tool-run.cpp
+++ b/datastore/nmdb-remove-tool-run/nmdb-remove-tool-run.cpp
@@ -77,7 +77,7 @@ class Tool : public nmdt::AbstractDatastoreTool
           const auto& results {t.exec_prepared("delete_tool_run", toolRunId)};
 
           LOG_INFO << "Removal count for " << uuidStr
-                   << ": " << std::size(results) << '\n'
+                   << ": " << results.affected_rows() << '\n'
                    ;
           } catch (std::exception& e) {
             LOG_WARN << "Skipping " << uuidStr


### PR DESCRIPTION
This PR includes:
- Updates to handle changes between Prowler v2 and v3 output.
  - The same tooling handles both (defaults to v3) and logic combines both for analysis.
- Cleanup of `nmdb-export-scans` to standardize the logic flow for exporting targeted scan data.
- Cleanup of sporadic trailing white space.