### PR TITLE
Bugfixes cisco show ip route

### DIFF
--- a/datastore/common/objects/IpNetwork.cpp
+++ b/datastore/common/objects/IpNetwork.cpp
@@ -166,7 +166,7 @@ namespace netmeld::datastore::objects {
   IpNetwork::setAddress(const std::string& _addr)
   {
     try {
-      address = IpAddr::from_string(_addr);
+      address = bai::make_address(_addr);
       setPrefix(prefix);
     } catch (std::exception& e) {
       LOG_ERROR << "IP address malformed for parser: " << _addr << std::endl;

--- a/datastore/common/objects/IpNetwork.hpp
+++ b/datastore/common/objects/IpNetwork.hpp
@@ -33,12 +33,14 @@
 
 #include <netmeld/datastore/objects/AbstractDatastoreObject.hpp>
 
-using IpAddr = boost::asio::ip::address;
+namespace bai = boost::asio::ip;
 
 
 namespace netmeld::datastore::objects {
 
   class IpNetwork : public AbstractDatastoreObject {
+    using IpAddr = bai::address;
+
     // =========================================================================
     // Variables
     // =========================================================================

--- a/datastore/common/objects/IpNetwork.test.cpp
+++ b/datastore/common/objects/IpNetwork.test.cpp
@@ -44,17 +44,10 @@ class TestIpNetwork : public nmdo::IpNetwork {
         IpNetwork(_ip, _desc) {};
 
   public:
-    IpAddr getAddress() const
-    { return address; }
-
-    size_t getPrefix() const
-    { return prefix; }
-
-    std::string getReason() const
-    { return reason; }
-
-    double getExtraWeight() const
-    { return extraWeight; }
+    using IpNetwork::address;
+    using IpNetwork::prefix;
+    using IpNetwork::reason;
+    using IpNetwork::extraWeight;
 
     template<size_t n>
     std::bitset<n> getBits() const
@@ -66,19 +59,19 @@ BOOST_AUTO_TEST_CASE(testConstructors)
   {
     TestIpNetwork ipNet;
 
-    BOOST_TEST(IpAddr() == ipNet.getAddress());
-    BOOST_TEST(UINT8_MAX == ipNet.getPrefix());
-    BOOST_TEST(ipNet.getReason().empty());
-    BOOST_TEST(0.0 == ipNet.getExtraWeight());
+    BOOST_TEST(bai::address() == ipNet.address);
+    BOOST_TEST(UINT8_MAX == ipNet.prefix);
+    BOOST_TEST(ipNet.reason.empty());
+    BOOST_TEST(0.0 == ipNet.extraWeight);
   }
 
   {
     TestIpNetwork ipNet {"10.0.0.1/24", "Some Description"};
 
-    BOOST_TEST(IpAddr::from_string("10.0.0.1") == ipNet.getAddress());
-    BOOST_TEST(24 == ipNet.getPrefix());
-    BOOST_TEST("Some Description" == ipNet.getReason());
-    BOOST_TEST(0.0 == ipNet.getExtraWeight());
+    BOOST_TEST(bai::address::from_string("10.0.0.1") == ipNet.address);
+    BOOST_TEST(24 == ipNet.prefix);
+    BOOST_TEST("Some Description" == ipNet.reason);
+    BOOST_TEST(0.0 == ipNet.extraWeight);
   }
 }
 
@@ -92,8 +85,8 @@ BOOST_AUTO_TEST_CASE(testSettersSimple)
 
     for (const auto& [ip, prefix] : testsOk) {
       TestIpNetwork ipNet {ip, ""};
-      BOOST_TEST(IpAddr::from_string(ip) == ipNet.getAddress());
-      BOOST_TEST(prefix == ipNet.getPrefix());
+      BOOST_TEST(bai::address::from_string(ip) == ipNet.address);
+      BOOST_TEST(prefix == ipNet.prefix);
 
     }
   }
@@ -102,30 +95,30 @@ BOOST_AUTO_TEST_CASE(testSettersSimple)
     TestIpNetwork ipNet;
 
     ipNet.setPrefix(15);
-    BOOST_TEST(15 == ipNet.getPrefix());
+    BOOST_TEST(15 == ipNet.prefix);
     ipNet.setPrefix(150);
-    BOOST_TEST(150 == ipNet.getPrefix());
+    BOOST_TEST(150 == ipNet.prefix);
   }
 
   {
     TestIpNetwork ipNet;
 
     ipNet.setExtraWeight(999.0);
-    BOOST_TEST(999.0 == ipNet.getExtraWeight());
+    BOOST_TEST(999.0 == ipNet.extraWeight);
 
     ipNet.setExtraWeight(boost::math::float_prior(999.0));
-    BOOST_TEST(999.0 != ipNet.getExtraWeight());
+    BOOST_TEST(999.0 != ipNet.extraWeight);
 
     ipNet.setExtraWeight(boost::math::float_next(999.0));
-    BOOST_TEST(999.0 != ipNet.getExtraWeight());
+    BOOST_TEST(999.0 != ipNet.extraWeight);
   }
 
   {
     TestIpNetwork ipNet;
 
-    BOOST_TEST(ipNet.getReason().empty());
+    BOOST_TEST(ipNet.reason.empty());
     ipNet.setReason("Some Reason");
-    BOOST_TEST("Some Reason" == ipNet.getReason());
+    BOOST_TEST("Some Reason" == ipNet.reason);
   }
 
   {
@@ -166,7 +159,7 @@ BOOST_AUTO_TEST_CASE(testSettersSimple)
     BOOST_TEST(dip == ipNet.toString());
 
     // ensure prefix is unsigned otherwise checks for below zero are needed
-    BOOST_TEST((typeid(size_t) == typeid(ipNet.getPrefix())));
+    BOOST_TEST((typeid(uint8_t) == typeid(ipNet.prefix)));
 
     ipNet.setAddress("1.2.3.255");
     ipNet.setPrefix(24);
@@ -261,21 +254,21 @@ BOOST_AUTO_TEST_CASE(testSettersMask)
 
     // Normal
     test.setNetmask(netmask);
-    BOOST_TEST(32 == test.getPrefix());
+    BOOST_TEST(32 == test.prefix);
     test.setWildcardMask(wildmask);
-    BOOST_TEST(32 == test.getPrefix());
+    BOOST_TEST(32 == test.prefix);
 
     // Guess -- always err to /0
     test.setMask(netmask);
-    BOOST_TEST(0 == test.getPrefix());
+    BOOST_TEST(0 == test.prefix);
     test.setMask(wildmask);
-    BOOST_TEST(0 == test.getPrefix());
+    BOOST_TEST(0 == test.prefix);
 
     // Bad
     test.setNetmask(wildmask);
-    BOOST_TEST(0 == test.getPrefix());
+    BOOST_TEST(0 == test.prefix);
     test.setWildcardMask(netmask);
-    BOOST_TEST(0 == test.getPrefix());
+    BOOST_TEST(0 == test.prefix);
   }
   { // IPv4 Wildmask and Netmask creation and test
     TestIpNetwork test       {"1.2.3.4", ""};
@@ -309,21 +302,21 @@ BOOST_AUTO_TEST_CASE(testSettersMask)
 
         // Normal
         test.setNetmask(netmask);
-        BOOST_TEST(prefix == test.getPrefix());
+        BOOST_TEST(prefix == test.prefix);
         test.setWildcardMask(wildmask);
-        BOOST_TEST(prefix == test.getPrefix());
+        BOOST_TEST(prefix == test.prefix);
 
         // Guess -- always err to /0
         test.setMask(netmask);
-        BOOST_TEST(prefix == test.getPrefix());
+        BOOST_TEST(prefix == test.prefix);
         test.setMask(wildmask);
-        BOOST_TEST(prefix == test.getPrefix());
+        BOOST_TEST(prefix == test.prefix);
 
         // Bad
         test.setNetmask(wildmask);
-        BOOST_TEST(maxPrefix == test.getPrefix());
+        BOOST_TEST(maxPrefix == test.prefix);
         test.setWildcardMask(netmask);
-        BOOST_TEST(maxPrefix == test.getPrefix());
+        BOOST_TEST(maxPrefix == test.prefix);
       }
     }
   }
@@ -359,21 +352,21 @@ BOOST_AUTO_TEST_CASE(testSettersMask)
 
         // Normal
         test.setNetmask(netmask);
-        BOOST_TEST(prefix == test.getPrefix());
+        BOOST_TEST(prefix == test.prefix);
         test.setWildcardMask(wildmask);
-        BOOST_TEST(prefix == test.getPrefix());
+        BOOST_TEST(prefix == test.prefix);
 
         // Guess -- always err to /0
         test.setMask(netmask);
-        BOOST_TEST(prefix == test.getPrefix());
+        BOOST_TEST(prefix == test.prefix);
         test.setMask(wildmask);
-        BOOST_TEST(prefix == test.getPrefix());
+        BOOST_TEST(prefix == test.prefix);
 
         // Bad
         test.setNetmask(wildmask);
-        BOOST_TEST(maxPrefix == test.getPrefix());
+        BOOST_TEST(maxPrefix == test.prefix);
         test.setWildcardMask(netmask);
-        BOOST_TEST(maxPrefix == test.getPrefix());
+        BOOST_TEST(maxPrefix == test.prefix);
       }
     }
   }
@@ -388,7 +381,7 @@ BOOST_AUTO_TEST_CASE(testSettersMask)
 
     for (const auto& [prefix, mask] : masks) {
       ipNet.setNetmask(nmdo::IpNetwork(mask));
-      BOOST_TEST(prefix == ipNet.getPrefix());
+      BOOST_TEST(prefix == ipNet.prefix);
     }
   }
 
@@ -407,7 +400,7 @@ BOOST_AUTO_TEST_CASE(testSettersMask)
       bool is_contiguous = ipNet.setWildcardMask(ipMask);
 
       BOOST_TEST(!is_contiguous);
-      BOOST_TEST(ipNet.getPrefix() == prefix);
+      BOOST_TEST(ipNet.prefix == prefix);
     }
   }
 }

--- a/datastore/common/objects/Route.cpp
+++ b/datastore/common/objects/Route.cpp
@@ -133,10 +133,12 @@ namespace netmeld::datastore::objects {
     //       - nextHopIpAddr is set
     //       - isNullRoute is true
     //       - nextVrfId and nextTableId is set
+    //       - outIfaceName is set
     return (  !dstIpNet.hasUnsetPrefix()
            && (  !nextHopIpAddr.hasUnsetPrefix()
               || isNullRoute
               || !(nextVrfId.empty() || nextTableId.empty())
+              || !outIfaceName.empty()
               )
            )
       ;
@@ -221,7 +223,7 @@ namespace netmeld::datastore::objects {
         << ", isActive: " << std::boolalpha << isActive
         << ", dstIpNet: " << dstIpNet.toDebugString()
         << ", nextVrfId: " << nextVrfId
-        << ", netxtTableId: " << nextTableId
+        << ", nextTableId: " << nextTableId
         << ", nextHopIpAddr: " << nextHopIpAddr.toDebugString()
         << ", outIfaceName: " << outIfaceName
         << ", protocol: " << protocol

--- a/datastore/common/objects/Route.test.cpp
+++ b/datastore/common/objects/Route.test.cpp
@@ -1,5 +1,5 @@
 // =============================================================================
-// Copyright 2023 National Technology & Engineering Solutions of Sandia, LLC
+// Copyright 2024 National Technology & Engineering Solutions of Sandia, LLC
 // (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
 // Government retains certain rights in this software.
 //
@@ -38,35 +38,16 @@ class TestRoute : public nmdo::Route {
     TestRoute() : Route() {};
 
   public:
-    std::string getVrfId() const
-    { return vrfId; }
-
-    std::string getTableId() const
-    { return tableId; }
-
-    nmdo::IpNetwork getDstIpNet() const
-    { return dstIpNet; }
-
-    std::string getNextVrfId() const
-    { return nextVrfId; }
-
-    std::string getNextTableId() const
-    { return nextTableId; }
-
-    nmdo::IpAddress getNextHopIpAddr() const
-    { return nextHopIpAddr; }
-
-    std::string getIfaceName() const
-    { return outIfaceName; }
-
-    std::string getProtocol() const
-    { return protocol; }
-
-    size_t getAdminDistance() const
-    { return adminDistance; }
-
-    size_t getMetric() const
-    { return metric; }
+    using Route::vrfId;
+    using Route::tableId;
+    using Route::dstIpNet;
+    using Route::nextVrfId;
+    using Route::nextTableId;
+    using Route::nextHopIpAddr;
+    using Route::outIfaceName;
+    using Route::protocol;
+    using Route::adminDistance;
+    using Route::metric;
 };
 
 BOOST_AUTO_TEST_CASE(testConstructors)
@@ -75,9 +56,9 @@ BOOST_AUTO_TEST_CASE(testConstructors)
   {
     TestRoute route;
 
-    BOOST_CHECK_EQUAL(ipAddr, route.getDstIpNet());
-    BOOST_CHECK_EQUAL(ipAddr, route.getNextHopIpAddr());
-    BOOST_CHECK(route.getIfaceName().empty());
+    BOOST_TEST(ipAddr == route.dstIpNet);
+    BOOST_TEST(ipAddr == route.nextHopIpAddr);
+    BOOST_TEST(route.outIfaceName.empty());
   }
 }
 
@@ -87,28 +68,28 @@ BOOST_AUTO_TEST_CASE(testSetters)
     TestRoute route;
 
     route.setVrfId("someVrfId");
-    BOOST_CHECK_EQUAL("someVrfId", route.getVrfId());
+    BOOST_TEST("someVrfId" == route.vrfId);
   }
 
   {
     TestRoute route;
 
     route.setNextVrfId("someVrfId");
-    BOOST_CHECK_EQUAL("someVrfId", route.getNextVrfId());
+    BOOST_TEST("someVrfId" == route.nextVrfId);
   }
 
   {
     TestRoute route;
 
     route.setTableId("someTableId");
-    BOOST_CHECK_EQUAL("someTableId", route.getTableId());
+    BOOST_TEST("someTableId" == route.tableId);
   }
 
   {
     TestRoute route;
 
     route.setNextTableId("someTableId");
-    BOOST_CHECK_EQUAL("someTableId", route.getNextTableId());
+    BOOST_TEST("someTableId" == route.nextTableId);
   }
 
   {
@@ -116,7 +97,7 @@ BOOST_AUTO_TEST_CASE(testSetters)
     nmdo::IpAddress ipAddr {"1.2.3.4/24"};
 
     route.setDstIpNet(ipAddr);
-    BOOST_CHECK_EQUAL(ipAddr, route.getDstIpNet());
+    BOOST_TEST(ipAddr == route.dstIpNet);
   }
 
   {
@@ -124,35 +105,35 @@ BOOST_AUTO_TEST_CASE(testSetters)
     nmdo::IpAddress ipAddr {"1.2.3.4/24"};
 
     route.setNextHopIpAddr(ipAddr);
-    BOOST_CHECK_EQUAL(ipAddr, route.getNextHopIpAddr());
+    BOOST_TEST(ipAddr == route.nextHopIpAddr);
   }
 
   {
     TestRoute route;
 
     route.setOutIfaceName("outIfaceName");
-    BOOST_CHECK_EQUAL("outifacename", route.getIfaceName());
+    BOOST_TEST("outifacename" == route.outIfaceName);
   }
 
   {
     TestRoute route;
 
     route.setProtocol("OSPF");
-    BOOST_CHECK_EQUAL("ospf", route.getProtocol());
+    BOOST_TEST("ospf" == route.protocol);
   }
 
   {
     TestRoute route;
 
     route.setAdminDistance(42);
-    BOOST_CHECK_EQUAL(42, route.getAdminDistance());
+    BOOST_TEST(42 == route.adminDistance);
   }
 
   {
     TestRoute route;
 
     route.setMetric(1000);
-    BOOST_CHECK_EQUAL(1000, route.getMetric());
+    BOOST_TEST(1000 == route.metric);
   }
 
   {
@@ -160,15 +141,15 @@ BOOST_AUTO_TEST_CASE(testSetters)
     nmdo::IpAddress tv1;
     nmdo::IpAddress tv2 {"1.2.3.4/24"};
 
-    BOOST_CHECK("" == route.getNextHopIpAddrString());
+    BOOST_TEST("" == route.getNextHopIpAddrString());
     route.setNextHopIpAddr(tv2);
-    BOOST_CHECK(tv2.toString() == route.getNextHopIpAddrString());
+    BOOST_TEST(tv2.toString() == route.getNextHopIpAddrString());
     route.setNullRoute(true);
-    BOOST_CHECK("" == route.getNextHopIpAddrString());
+    BOOST_TEST("" == route.getNextHopIpAddrString());
     route.setNullRoute(false);
-    BOOST_CHECK(tv2.toString() == route.getNextHopIpAddrString());
+    BOOST_TEST(tv2.toString() == route.getNextHopIpAddrString());
     route.setNextHopIpAddr(tv1);
-    BOOST_CHECK("" == route.getNextHopIpAddrString());
+    BOOST_TEST("" == route.getNextHopIpAddrString());
   }
 }
 
@@ -180,31 +161,40 @@ BOOST_AUTO_TEST_CASE(testValidity)
     {
       TestRoute route;
 
-      BOOST_CHECK(!route.isValid());
+      BOOST_TEST(!route.isValid());
       route.setDstIpNet(ipAddr);
-      BOOST_CHECK(!route.isValid());
+      BOOST_TEST(!route.isValid());
       route.setNullRoute(true);
-      BOOST_CHECK(route.isValid());
+      BOOST_TEST(route.isValid());
     }
     {
       TestRoute route;
 
-      BOOST_CHECK(!route.isValid());
+      BOOST_TEST(!route.isValid());
       route.setDstIpNet(ipAddr);
-      BOOST_CHECK(!route.isValid());
+      BOOST_TEST(!route.isValid());
       route.setNextHopIpAddr(ipAddr);
-      BOOST_CHECK(route.isValid());
+      BOOST_TEST(route.isValid());
     }
     {
       TestRoute route;
 
-      BOOST_CHECK(!route.isValid());
+      BOOST_TEST(!route.isValid());
       route.setDstIpNet(ipAddr);
-      BOOST_CHECK(!route.isValid());
+      BOOST_TEST(!route.isValid());
       route.setNextVrfId("test");
-      BOOST_CHECK(!route.isValid());
+      BOOST_TEST(!route.isValid());
       route.setNextTableId("test");
-      BOOST_CHECK(route.isValid());
+      BOOST_TEST(route.isValid());
+    }
+    {
+      TestRoute route;
+
+      BOOST_TEST(!route.isValid());
+      route.setDstIpNet(ipAddr);
+      BOOST_TEST(!route.isValid());
+      route.setOutIfaceName("test");
+      BOOST_TEST(route.isValid());
     }
   }
 
@@ -212,10 +202,10 @@ BOOST_AUTO_TEST_CASE(testValidity)
     TestRoute route;
     nmdo::IpAddress ipAddr;
 
-    BOOST_CHECK(ipAddr.hasUnsetPrefix());
+    BOOST_TEST(ipAddr.hasUnsetPrefix());
     route.setNextHopIpAddr(ipAddr);
-    BOOST_CHECK(!route.isValid());
+    BOOST_TEST(!route.isValid());
     route.setDstIpNet(ipAddr);
-    BOOST_CHECK(!route.isValid());
+    BOOST_TEST(!route.isValid());
   }
 }

--- a/datastore/common/parsers/ParserIpAddress.test.cpp
+++ b/datastore/common/parsers/ParserIpAddress.test.cpp
@@ -36,8 +36,8 @@ namespace nmdo = netmeld::datastore::objects;
 namespace nmdp = netmeld::datastore::parsers;
 
 
-#include <netmeld/core/utils/LoggerSingleton.hpp>
-namespace nmcu = netmeld::core::utils;
+//#include <netmeld/core/utils/LoggerSingleton.hpp>
+//namespace nmcu = netmeld::core::utils;
 
 BOOST_AUTO_TEST_CASE(testWellformedWithPrefix)
 {

--- a/datastore/common/parsers/ParserIpAddress.test.cpp
+++ b/datastore/common/parsers/ParserIpAddress.test.cpp
@@ -35,6 +35,10 @@
 namespace nmdo = netmeld::datastore::objects;
 namespace nmdp = netmeld::datastore::parsers;
 
+
+#include <netmeld/core/utils/LoggerSingleton.hpp>
+namespace nmcu = netmeld::core::utils;
+
 BOOST_AUTO_TEST_CASE(testWellformedWithPrefix)
 {
   std::vector<std::string> ips {
@@ -44,19 +48,28 @@ BOOST_AUTO_TEST_CASE(testWellformedWithPrefix)
     , "255.255.255.255/32"
     , "1.12.255.0/24"
     , "12.1.4.255/10"
+    , "1:2:3:4:5:6:7:8/128"
     , "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/128"
+    , "1:2:3:4:5:6::/64"
     , "ffff:ffff:ffff:ffff:ffff:ffff::/64"
+    , "1:2:3:4:5::6/64"
     , "ffff:ffff:ffff:ffff:ffff::ffff/64"
+    , "::1:2:3:4:5:6/64"
     , "::ffff:ffff:ffff:ffff:ffff:ffff/64"
+    , "1::2/64"
     , "ffff::ffff/64"
+    , "1::/8"
     , "ffff::/8"
+    , "::1/15"
     , "::ffff/15"
-    , "2001:db8:1::23:456:789/48"
+    , "2001:db8:1::23:4567:890/48"
     };
 
   for (const auto& ip : ips) {
-    auto temp = nmdp::fromString<nmdp::ParserIpAddress, nmdo::IpAddress>(ip);
-    BOOST_TEST(ip == temp.toString());
+    const auto out {
+        nmdp::fromString<nmdp::ParserIpAddress, nmdo::IpAddress>(ip)
+      };
+    BOOST_TEST(ip == out.toString());
   }
 }
 
@@ -69,37 +82,88 @@ BOOST_AUTO_TEST_CASE(testWellformedNoPrefixV4)
     };
 
   for (const auto& ip : ips) {
-    auto temp = nmdp::fromString<nmdp::ParserIpv4Address, nmdo::IpAddress>(ip);
-    auto tempIp = ip + "/32";
-    BOOST_TEST(tempIp == temp.toString());
-  }
+    const auto out1 {
+        nmdp::fromString<nmdp::ParserIpv4Address, nmdo::IpAddress>(ip)
+      };
+    const auto out2 {
+        nmdp::fromString<nmdp::ParserIpAddress, nmdo::IpAddress>(ip)
+      };
 
-  for (const auto& ip : ips) {
-    auto temp = nmdp::fromString<nmdp::ParserIpAddress, nmdo::IpAddress>(ip);
-    auto tempIp = ip + "/32";
-    BOOST_TEST(tempIp == temp.toString());
+    BOOST_TEST(out1 == out2);
+
+    BOOST_TEST(out1.toString().ends_with("/32"));
   }
 }
 
 BOOST_AUTO_TEST_CASE(testWellformedNoPrefixV6)
 {
   std::vector<std::string> ips {
-      "::"
-    , "::1"
-    , "2001:db8:1:a::ffff"
+      "2001:db8:1:a::ffff"
     , "2001:db8:1:a:b:23:456:789"
+    // some permutations
+    , "1:2:3:4:5:6:7:8"
+    , "1:2:3:4:5:6::"
+    , "1:2:3:4:5::"
+    , "1:2:3:4::"
+    , "1:2:3::"
+    , "1:2::"
+    , "1::"
+    , "1::4:5:6:7:8"
+    , "1::5:6:7:8"
+    , "1::6:7:8"
+    , "1::7:8"
+    , "1::8"
+    , "1:2::5:6:7:8"
+    , "1:2::6:7:8"
+    , "1:2::7:8"
+    , "1:2::8"
+    , "1:2:3::6:7:8"
+    , "1:2:3::7:8"
+    , "1:2:3::8"
+    , "1:2:3:4::7:8"
+    , "1:2:3:4::8"
+    , "1:2:3:4:5::8"
+    , "::3:4:5:6:7:8"
+    , "::4:5:6:7:8"
+    , "::5:6:7:8"
+    , "::6:7:8"
+    , "::7:8"
+    , "::8"
+    , "::"
+    // v4 mapped v6
+    , "1:2:3:4:5:6:1.2.3.4"
+    , "1:2:3:4::1.2.3.4"
+    , "1:2:3::1.2.3.4"
+    , "1:2::1.2.3.4"
+    , "1::1.2.3.4"
+    , "1::4:5:6:1.2.3.4"
+    , "1::5:6:1.2.3.4"
+    , "1::6:1.2.3.4"
+    , "1:2::5:6:1.2.3.4"
+    , "1:2::6:1.2.3.4"
+    , "1:2::1.2.3.4"
+    , "1:2:3::6:1.2.3.4"
+    , "1:2:3::1.2.3.4"
+    , "1:2:3::8:1.2.3.4"
+    , "1:2:3:4::1.2.3.4"
+    , "::3:4:5:6:1.2.3.4"
+    , "::4:5:6:1.2.3.4"
+    , "::5:6:1.2.3.4"
+    , "::6:1.2.3.4"
+    , "::1.2.3.4"
     };
 
   for (const auto& ip : ips) {
-    auto temp = nmdp::fromString<nmdp::ParserIpv6Address, nmdo::IpAddress>(ip);
-    auto tempIp = ip + "/128";
-    BOOST_TEST(tempIp == temp.toString());
-  }
+    const auto out1 {
+        nmdp::fromString<nmdp::ParserIpv6Address, nmdo::IpAddress>(ip)
+      };
+    const auto out2 {
+        nmdp::fromString<nmdp::ParserIpAddress, nmdo::IpAddress>(ip)
+      };
 
-  for (const auto& ip : ips) {
-    auto temp = nmdp::fromString<nmdp::ParserIpAddress, nmdo::IpAddress>(ip);
-    auto tempIp = ip + "/128";
-    BOOST_TEST(tempIp == temp.toString());
+    BOOST_TEST(out1 == out2);
+
+    BOOST_TEST(out1.toString().ends_with("/128"));
   }
 }
 
@@ -110,7 +174,10 @@ BOOST_AUTO_TEST_CASE(testMalformedNotFullyParsed)
     , "255.255.255.255/5.255.255.255"
     , "1.1.1.1/g"
     , "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"
+    , "ffff:ffff:ffff:ffff::ffff:ffff:ffff:ffff"
     , "ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffg/128"
+    , "1:2:3:4:5:6:7:8:1.2.3.4"
+    , "1:2:3:4:5:6::1.2.3.4"
     };
 
   for (const auto& ip : ips) {
@@ -127,13 +194,13 @@ BOOST_AUTO_TEST_CASE(testMalformedNotFullyParsed)
 
 BOOST_AUTO_TEST_CASE(testMalformedParseFail)
 {
+  //nmcu::LoggerSingleton::getInstance().setLevel(nmcu::Severity::ALL);
   std::vector<std::string> ips {
       "1.2.3.1001"
     , "2001:db8:1:a:b"
     , "192.168 .1.10"
     , "1.1.1.256"
     , "aa:bb:cc:dd:ee:ff"
-    , "ffff:ffff:ffff:ffff::ffff:ffff:ffff:ffff"
     , "ffff:ffff:ffff:ffff:ffff:ffff:ffff:gfff/128"
   };
 
@@ -144,8 +211,13 @@ BOOST_AUTO_TEST_CASE(testMalformedParseFail)
     nmdp::IstreamIter i(dataStream), e;
     bool const success = qi::parse(i, e, nmdp::ParserIpAddress(), result);
 
-    BOOST_TEST(!success, "Parser incorrectly succeeded on: " << ip);
-    BOOST_TEST((i != e), "Incorrect full parse on: " << ip);
-    std::cout << result << std::endl;
+    BOOST_TEST( !success
+              , "Parser incorrectly succeeded on: " << ip
+                << " -- Result: " << result
+              );
+    BOOST_TEST( (i != e)
+              , "Incorrect full parse on: " << ip
+                << " -- Result: " << result
+              );
   }
 }

--- a/datastore/importers/nmdb-import-cisco-show-ip-route/Parser.cpp
+++ b/datastore/importers/nmdb-import-cisco-show-ip-route/Parser.cpp
@@ -50,6 +50,8 @@ Parser::Parser() : Parser::base_type(start)
     >> *((!vrfHeader) >> (ignoredLine | qi::eol))
     ;
 
+  // ----- VRF header related -----
+
   vrfHeader =
     ( (vrfHeaderIos > qi::eps(pnx::ref(isIos) = true))
     | (vrfHeaderNxos > qi::eps(pnx::ref(isNxos) = true))
@@ -107,6 +109,8 @@ Parser::Parser() : Parser::base_type(start)
     >> qi::char_("rR") >> qi::lit("outing ")
     > qi::eps[(pnx::ref(isIpv6) = true)]
     ;
+
+  // ----- IPv4 route table related -----
 
   ipv4Route %=
     qi::eps[(pnx::ref(curIfaceName) = "")]
@@ -200,6 +204,8 @@ Parser::Parser() : Parser::base_type(start)
     | ifaceName(qi::_r1)
     ;
 
+  // ----- IPv6 route table related -----
+
   ipv6Route %=
     qi::eps[(pnx::ref(curIfaceName) = "")]
     >> ( (qi::eps(pnx::ref(isIos)) >> ipv6RouteIos)
@@ -267,6 +273,8 @@ Parser::Parser() : Parser::base_type(start)
     ipv6Addr [(pnx::bind(&nmdo::Route::setNextHopIpAddr, &qi::_r1, qi::_1))]
     > -egressVrf(qi::_r1)
     ;
+
+  // ----- Both v4/6 related -----
 
   distanceMetric = // [distance/metric]
     ( ( qi::lit('[') > qi::uint_ > qi::lit('/') > qi::uint_ > qi::lit(']')

--- a/datastore/importers/nmdb-import-cisco-show-ip-route/Parser.hpp
+++ b/datastore/importers/nmdb-import-cisco-show-ip-route/Parser.hpp
@@ -62,15 +62,22 @@ class Parser:
   private:
   protected:
     const std::string DEFAULT_VRF_ID  {""};//{"default"};
-    std::string       currVrf         {DEFAULT_VRF_ID};
-    std::string       currProtocol;
 
-    unsigned int currAdminDistance {0};
-    unsigned int currMetric {0};
+    std::string       curVrf         {DEFAULT_VRF_ID};
+    std::string       curProtocol;
+    std::string       curIfaceName;
 
-    nmdo::IpNetwork currDstIpNet;
+    unsigned int curAdminDistance {0};
+    unsigned int curMetric {0};
 
-    nmdo::ToolObservations currObservations;
+    nmdo::IpNetwork curDstIpNet;
+
+    nmdo::ToolObservations curObservations;
+
+    bool isIpv6   {false};
+    bool isIos    {false};
+    bool isIosOld {false};
+    bool isNxos   {false};
 
     std::map<std::string, std::string> typeCodeLookups {
           {"%", ""} // next-hop override
@@ -138,6 +145,8 @@ class Parser:
       , ipv6Route
       , ipv4RouteIos
       , ipv6RouteIos
+      , ipv4RouteIosOld
+      , ipv6RouteIosOld
       , ipv4RouteNxos
       , ipv6RouteNxos
       ;
@@ -160,16 +169,16 @@ class Parser:
         ipv6Addr
       ;
 
-    qi::rule<nmdp::IstreamIter, std::string(), qi::ascii::blank_type>
+    qi::rule<nmdp::IstreamIter, qi::ascii::blank_type>
         vrfHeader
       , vrfHeaderIos
+      , vrfHeaderIosOld
       , vrfHeaderNxos
       ;
 
     qi::rule<nmdp::IstreamIter, std::string()>
         csvToken
       , token
-      , egressVrf
       ;
 
     qi::rule<nmdp::IstreamIter, qi::ascii::blank_type>
@@ -180,17 +189,19 @@ class Parser:
     qi::rule<nmdp::IstreamIter>
         vrfName
       , altRoutePath
+      , ipv6Routing
       ;
 
     qi::rule<nmdp::IstreamIter, void(nmdo::Route&), qi::ascii::blank_type>
         distanceMetric
       , ipv4TypeCodeDstIpNet
-      , ipv6TypeCodeDstIpNet
+      , ipv6DstLineIos
       , ifaceName
       , rtrIpv4Addr
       , rtrIpv6Addr
       , dstIpv4Net
       , dstIpv6Net
+      , egressVrf
       ;
 
     qi::rule<nmdp::IstreamIter, void(nmdo::Route&)>
@@ -217,5 +228,4 @@ class Parser:
     void updateDstIpNet(nmdo::Route&, nmdo::IpNetwork&);
     void updateDistanceMetric(nmdo::Route&, unsigned int, unsigned int);
 };
-
 #endif // PARSER_HPP

--- a/datastore/importers/nmdb-import-cisco-show-ip-route/Parser.test.cpp
+++ b/datastore/importers/nmdb-import-cisco-show-ip-route/Parser.test.cpp
@@ -61,63 +61,170 @@ class TestParser : public Parser
     using Parser::typeCode;
     using Parser::typeCodeLookups;
     using Parser::uptime;
-    using Parser::currObservations;
+    using Parser::curObservations;
     using Parser::vrfHeader;
+
+    using Parser::isIos;
+    using Parser::isIosOld;
+    using Parser::isNxos;
 };
 
-BOOST_AUTO_TEST_CASE(testRules)
+BOOST_AUTO_TEST_CASE(testRulesUptime)
 {
-  {
-    TestParser tp;
-    const auto& parserRule {tp.uptime};
+  TestParser tp;
+  const auto& parserRule {tp.uptime};
 
-    std::vector<std::string> testsOk {
-      // hh:mm:ss     -- unknown if hours has max value
-        R"(01:23:45)"
-      , R"(1234:12:12)"
-      // 0d0h | 0w0d  -- 0 can be any positive numeral
-      , R"(1d2h)"
-      , R"(365d23h)"
-      , R"(1w2d)"
-      , R"(56w6d)"
-      };
-    for (const auto& test : testsOk) {
-      BOOST_TEST( nmdp::test(test.c_str(), parserRule, blank)
-                , "Rule 'uptime': " << test
-                );
-    }
-
-    std::vector<std::string> testsBad {
-        R"(12:34:56:78)"
-      , R"(12:34)"
-      , R"(1a2b)"
-      , R"(1d2b)"
-      , R"(1w2b)"
-      };
-    for (const auto& test : testsBad) {
-      BOOST_TEST(!nmdp::test(test.c_str(), parserRule, blank)
-                , "Rule '!uptime': " << test
-                );
-    }
+  std::vector<std::string> testsOk {
+    // hh:mm:ss     -- unknown if hours has max value
+      R"(01:23:45)"
+    , R"(1234:12:12)"
+    // 0d0h | 0w0d  -- 0 can be any positive numeral
+    , R"(1d2h)"
+    , R"(365d23h)"
+    , R"(1w2d)"
+    , R"(56w6d)"
+    // 0.000000
+    , R"(0.000000)"
+    };
+  for (const auto& test : testsOk) {
+    BOOST_TEST( nmdp::test(test.c_str(), parserRule, blank)
+              , "Rule 'uptime': " << test
+              );
   }
-  {
-    TestParser tp;
+
+  std::vector<std::string> testsBad {
+      R"(12:34:56:78)"
+    , R"(12:34)"
+    , R"(1a2b)"
+    , R"(1d2b)"
+    , R"(1w2b)"
+    , R"(1.000000)"
+    , R"(0.123456)"
+    };
+  for (const auto& test : testsBad) {
+    BOOST_TEST(!nmdp::test(test.c_str(), parserRule, blank)
+              , "Rule '!uptime': " << test
+              );
+  }
+}
+
+BOOST_AUTO_TEST_CASE(testVrfHeader)
+{
+  TestParser tp;
+  const auto& parserRule {tp.vrfHeader};
+
+  {// IOS/ASA
+    std::vector<std::string> testsOk {
+        "Codes: A - some1\n"
+      , "Codes: A - some1, B - some2\n C - some3\n"
+      , "VRF: default\nCodes: A - some1\n"
+      , R"(VRF name: default
+           Displaying 0 of 0 IPv6 routing table entries
+           IPv6 Routing Table - 0 entries
+           Codes: A - some1, B - some2
+                  C - some3
+
+           Gateway of last resort is not set
+        )"
+      };
+
+    for (const auto& test : testsOk) {
+      std::string out;
+      BOOST_TEST( nmdp::testAttr(test.c_str(), parserRule, out, blank)
+                , "Rule 'vrfHeader': " << test
+                );
+      BOOST_TEST("" == out);
+      BOOST_TEST(tp.isIos);
+      BOOST_TEST(!tp.isIosOld);
+      BOOST_TEST(!tp.isNxos);
+    }
+    tp.isIos = false;
+  }
+
+  {// IOS old
+    std::vector<std::string> testsOk {
+        R"(Default gateway is 1.2.3.4
+
+      Host               Gateway           Last Use    Total Uses  Interface
+      )"
+      };
+
+    for (const auto& test : testsOk) {
+      std::string out;
+      BOOST_TEST( nmdp::testAttr(test.c_str(), parserRule, out, blank)
+                , "Rule 'vrfHeader': " << test
+                );
+      BOOST_TEST("" == out);
+      BOOST_TEST(!tp.isIos);
+      BOOST_TEST(tp.isIosOld);
+      BOOST_TEST(!tp.isNxos);
+    }
+    tp.isIosOld = false;
+  }
+
+  {// NXOS
+    std::vector<std::string> testsOk {
+        R"(IP Route Table for VRF "default"
+           '*' denotes best ucast next-hop
+           '**' denotes best mcast next-hop
+           '[x/y]' denotes [preference/metric]
+           '%<string>' in via output denotes VRF <string>
+        )"
+      , R"(IPv6 Routing Table for VRF "default"
+           '*' denotes best ucast next-hop
+           '**' denotes best mcast next-hop
+           '[x/y]' denotes [preference/metric]
+        )"
+      };
+
+    for (const auto& test : testsOk) {
+      std::string out;
+      BOOST_TEST( nmdp::testAttr(test.c_str(), parserRule, out, blank)
+                , "Rule 'vrfHeader': " << test
+                );
+      BOOST_TEST("" == out);
+      BOOST_TEST(!tp.isIos);
+      BOOST_TEST(!tp.isIosOld);
+      BOOST_TEST(tp.isNxos);
+    }
+    tp.isNxos = false;
+  }
+}
+
+BOOST_AUTO_TEST_CASE(testRulesIpRouteBad)
+{
+  TestParser tp;
+
+  // turn everything on, should all fail
+  tp.isIos = true;
+  tp.isIosOld = true;
+  tp.isNxos = true;
+
+  const auto& parserRule {tp.ipv4Route};
+
+  std::vector<std::string> testsOkInvalidRoute {
+      R"(1.2.3.0/24 is subnetted, junk, data)"
+    , R"(     1.2.3.0/24 is variably subnetted, junk, data)"
+    };
+
+  for (const auto& test : testsOkInvalidRoute) {
+    nmdo::Route out;
+    BOOST_TEST( nmdp::testAttr(test.c_str(), parserRule, out, blank)
+              , "Rule 'ipv4Route': " << test
+              );
+    BOOST_TEST(!out.isValid());
+  }
+}
+
+BOOST_AUTO_TEST_CASE(testRulesIpRouteIos)
+{
+  TestParser tp;
+  tp.isIos = true;
+
+  { // IPv4
     const auto& parserRule {tp.ipv4Route};
 
-    std::vector<std::string> testsOkInvalidRoute {
-        R"(1.2.3.0/24 is subnetted, junk, data)"
-      , R"(     1.2.3.0/24 is variably subnetted, junk, data)"
-      };
-
-    for (const auto& test : testsOkInvalidRoute) {
-      nmdo::Route out;
-      BOOST_TEST( nmdp::testAttr(test.c_str(), parserRule, out, blank)
-                , "Rule 'ipv4Route': " << test
-                );
-      BOOST_TEST(!out.isValid());
-    }
-
-    std::vector<std::string> testsOkValidRoute {
+    std::vector<std::string> testsOk {
       // IOS/ASA/ASR like
         R"(C    1.2.3.0/24 is directly connected, nic)"
       , R"(C    1.2.3.0/24 is directly connected, nic.1)"
@@ -153,35 +260,9 @@ BOOST_AUTO_TEST_CASE(testRules)
 
       // ASR null route
       , R"(B    0.0.0.0/0 [1/2], 1w1d, Null0)"
-
-      // NXOS like
-      , R"(1.2.3.0/24, ubest/mbest: 1/0
-              *via 1.2.3.1, [1/2], 1w2d, static)"
-      , R"(1.2.3.0/24, ubest/mbest: 1/0
-              *via 1.2.3.1, nic, [1/2], 1w2d, static)"
-      , R"(1.2.3.0/24, ubest/mbest: 1/0, attached
-              *via 1.2.3.1, nic, [1/2], 1w2d, direct)"
-      , R"(1.2.3.0/24, ubest/mbest: 1/0
-              *via 1.2.3.1, nic, [1/2], 1w2d, eigrp-100, external, tag 1)"
-      // "one" test, three lines
-      , R"(1.2.3.255/32, ubest/mbest: 2/0, attached
-              *via 1.2.3.1, nic, [0/0], 1w2d, local)"
-      , R"(   *via 1.2.3.2, nic, [0/0], 1w2d, direct)"
-// TODO routes via Null0; drops
-      , R"(1.2.3.0/24, ubest/mbest: 1/0
-              *via Null0, [1/2], 1w2d, ospfv3-100, discard)"
-// TODO routes via interface
-      , R"(1.2.3.0/24, ubest/mbest: 1/0
-              *via nic, [1/2], 1w2d, ospfv3-1, intra)"
-// TODO routes via internal route; same config
-      , R"(1.2.3.0/24, ubest/mbest: 1/0
-              *via 1.2.3.4, [1/2], 1w2d, bgp-123, internal, tag 123)"
-// TODO routes via internal route; possible other config
-      , R"(1.2.3.0/24, ubest/mbest: 1/0
-              *via 1.2.3.4%default, [1/2], 1d2h, bgp-123, external, tag 123 (mpls-vpn))"
       };
 
-    for (const auto& test : testsOkValidRoute) {
+    for (const auto& test : testsOk) {
       nmdo::Route out;
       BOOST_TEST( nmdp::testAttr(test.c_str(), parserRule, out, blank)
                 , "Rule 'ipv4Route': " << test
@@ -193,28 +274,13 @@ BOOST_AUTO_TEST_CASE(testRules)
       if (std::string::npos != debugStr.find("outIfaceName: null0")) {
         nmdp::testInString(debugStr, "isNullRoute: true");
       }
+      if (std::string::npos != test.find("%default,")) {
+        nmdp::testInString(debugStr, "nextVrfId: default,");
+      }
     }
 
-    std::vector<std::string> testsOkUnsupported {
-        R"(C    net-list 255.255.255.0 is directly connected, nic)"
-      , R"(B    1.0.0.0 255.255.255.0 [1/2] via rtr-alias, nic)"
-      , R"(B    net-list 255.255.255.0 [1/2] via 1.2.3.4, 01:02:03, nic)"
-      , R"(B    net-list 255.255.255.0 [1/2] via rtr-alias, nic)"
-      };
-
-    for (const auto& test : testsOkUnsupported) {
-      nmdo::Route out;
-      BOOST_TEST( nmdp::testAttr(test.c_str(), parserRule, out, blank)
-                , "Rule 'ipv4Route': " << test
-                );
-      const auto debugStr {out.toDebugString()};
-      BOOST_TEST(!out.isValid(), debugStr);
-    }
-    const auto debugStr {tp.currObservations.toDebugString()};
-    nmdp::testInString(debugStr, "Router alias -- rtr-alias");
-    nmdp::testInString(debugStr, "Subnet alias -- net-list");
-
-    std::vector<std::string> testsOkMultiRoute {
+    // ------------------------------------------------------------------------
+    std::vector<std::string> testsMultiRoute {
       // "one" test, two lines
         R"(B L  0.0.0.0 255.255.255.255 [1/2] via 1.2.3.4, 01:02:03, nic1)"
       , R"(                             [1/2] via 1.2.3.5, 01:02:03, nic2)"
@@ -226,7 +292,7 @@ BOOST_AUTO_TEST_CASE(testRules)
       , R"(                                     via 1.2.3.5, nic2 (egress VRF n3))"
       };
     bool isFirst {true};
-    for (const auto& test : testsOkMultiRoute) {
+    for (const auto& test : testsMultiRoute) {
       nmdo::Route out;
       BOOST_TEST( nmdp::testAttr(test.c_str(), parserRule, out, blank)
                 , "Rule 'ipv4Route': " << test
@@ -245,6 +311,7 @@ BOOST_AUTO_TEST_CASE(testRules)
       nmdp::testInString(debugStr, R"(metric: 2)");
     }
 
+    // ------------------------------------------------------------------------
     std::vector<std::string> testsNextVrf {
         R"(B L  0.0.0.0/0 [1/2] (source VRF n1) via 1.2.3.4, nic1 (egress VRF n2))"
       , R"(C    0.0.0.0/0 is directly connected (source VRF n1), nic2 (egress VRF n3))"
@@ -268,45 +335,90 @@ BOOST_AUTO_TEST_CASE(testRules)
       isFirst = !isFirst;
     }
   }
-  {
-    TestParser tp;
+
+  {// IPv6
     const auto& parserRule {tp.ipv6Route};
 
-    std::vector<std::string> testsOkValidRoute {
+    std::vector<std::string> testsOk {
         R"(C    1::/64 [1/2]
                   via nic, directly connected)"
       , R"(C    1::/64 [1/2]
                   via Null0, directly connected)"
       , R"(B    1::/62 [1/2]
                   via 1::1, nic)"
+      , R"(B    1::/96 [1/2]
+                  via 1::1)"
       , R"(S    ::/0 [1/2]
                   via 1::1, nic)"
       , R"(B L  1::/64 [1/2] (source VRF A)
                   via nic (egress VRF A), directly connected)"
       , R"(B L  1::/64 [1/2] (source VRF A)
                   via 1::1, nic (egress VRF A))"
-      // NXOS like
-      , R"(1::/64, ubest/mbest: 1/0
-              *via 1::1/64, nic, [1/2], 1w2d, static)"
-      , R"(1::/64, ubest/mbest: 1/0, attached
-              *via 1::1/64, nic, [1/2], 1w2d, direct)"
-      , R"(1::/64, ubest/mbest: 1/0
-              *via 1::1/64, nic, [1/2], 1w2d, eigrp-100, external, tag 1)"
-// TODO routes via Null0; drops
-      , R"(1::/48, ubest/mbest: 1/0
-              *via Null0, [1/2], 1w2d, ospfv3-100, discard)"
-// TODO routes via interface
-      , R"(1::/48, ubest/mbest: 1/0
-              *via nic, [1/2], 1w2d, ospfv3-1, intra)"
-// TODO routes via internal route; same config
-      , R"(1::/128, ubest/mbest: 1/0
-              *via 1::1/128, [1/2], 1w2d, bgp-123, internal, tag 123)"
-// TODO routes via internal route; other config
-      , R"(1::/128, ubest/mbest: 1/0
-              *via ::f:1.2.3.4%default:IPv4, [1/2], 1d2h, bgp-123, external, tag 123 (mpls-vpn))"
       };
 
-    for (const auto& test : testsOkValidRoute) {
+    for (const auto& test : testsOk) {
+      nmdo::Route out;
+      BOOST_TEST( nmdp::testAttr(test.c_str(), parserRule, out, blank)
+                , "Rule 'ipv6Route': " << test
+                );
+      const auto debugStr {out.toDebugString()};
+      BOOST_TEST(out.isValid()
+                , "Validity failure: " << test
+                  << "\nGot: " << debugStr
+                );
+      if (std::string::npos != debugStr.find("outIfaceName: null0")) {
+        nmdp::testInString(debugStr, "isNullRoute: true");
+      }
+    }
+  }
+}
+
+BOOST_AUTO_TEST_CASE(testRulesIpRouteIosOld)
+{
+  TestParser tp;
+  tp.isIosOld = true;
+
+  {// IPv4
+    const auto& parserRule {tp.ipv4Route};
+
+    std::vector<std::string> testsOk {
+        "1.2.3.4\t1.2.3.5\t1:00\t12345\tnic1"
+      , "1.2.3.4  1.2.3.5  1:00  12345  nic1"
+      , " 1.2.3.4  1.2.3.5  1:00  12345  nic1   "
+      , "1.2.3.4  1.2.3.5  0:00  0  nic1"
+      };
+
+    for (const auto& test : testsOk) {
+      nmdo::Route out;
+      BOOST_TEST( nmdp::testAttr(test.c_str(), parserRule, out, blank)
+                , "Rule 'ipv4Route': " << test
+                );
+      const auto debugStr {out.toDebugString()};
+      BOOST_TEST(out.isValid()
+                , "Validity failure: " + test + "\n\tYielded: " + debugStr
+                );
+    }
+  }
+
+  {// IPv6
+    const auto& parserRule {tp.ipv6Route};
+
+    std::vector<std::string> testsOk {
+        "C   1::/64 [0/0]\n\t\tvia nic1, directly connected"
+      , "L   1::/64 [0/0]\n\t\tvia nic1, receive"
+      , "L   1::/64 [0/0]\n\t\tvia 1::3"
+      , "L   1::/64 [0/0]\n\t\tvia 2::3, nic1"
+      , "L   1::/64 [0/0], tag 123\n\t\tvia 1::3"
+      , "L   1::/64 [0/0]\n\t\tvia Null0"
+      , "L   1::/64 [0/0]\n\t\tvia Null0, receive"
+      // "one" test, two lines
+      , "L   1::/64 [0/0]\n\t\tvia 1::3"
+      , "      via 1::4"
+      , "L   1::/64 [0/0]\n\t\tvia 2::3, nic1"
+      , "      via 2::4, nic2"
+      };
+
+    for (const auto& test : testsOk) {
       nmdo::Route out;
       BOOST_TEST( nmdp::testAttr(test.c_str(), parserRule, out, blank)
                 , "Rule 'ipv6Route': " << test
@@ -315,61 +427,177 @@ BOOST_AUTO_TEST_CASE(testRules)
       BOOST_TEST(out.isValid()
                 , "Validity failure: " + test + "\n\tYielded: " + debugStr
                 );
-      if (std::string::npos != debugStr.find("outIfaceName: null0")) {
-        nmdp::testInString(debugStr, "isNullRoute: true");
+
+      if (std::string::npos != test.find("via nic1")) {
+        nmdp::testInString(debugStr, "outIfaceName: nic1,");
       }
-    }
-  }
-  {
-    TestParser tp;
-    const auto& parserRule {tp.vrfHeader};
-
-    std::vector<std::string> testsOk {
-      // ASA/IOS like
-        "Codes: A - some1\n"
-      , "Codes: A - some1, B - some2\n C - some3\n"
-      , "VRF: default\nCodes: A - some1\n"
-      , R"(VRF name: default
-           Displaying 0 of 0 IPv6 routing table entries
-           IPv6 Routing Table - 0 entries
-           Codes: A - some1, B - some2
-                  C - some3
-
-           Gateway of last resort is not set
-        )"
-      // NXOS like
-      , R"(IP Route Table for VRF "default"
-           '*' denotes best ucast next-hop
-           '**' denotes best mcast next-hop
-           '[x/y]' denotes [preference/metric]
-           '%<string>' in via output denotes VRF <string>
-        )"
-      , R"(IPv6 Routing Table for VRF "default"
-           '*' denotes best ucast next-hop
-           '**' denotes best mcast next-hop
-           '[x/y]' denotes [preference/metric]
-        )"
-      };
-
-    for (const auto& test : testsOk) {
-      std::string out;
-      BOOST_TEST( nmdp::testAttr(test.c_str(), parserRule, out, blank)
-                , "Rule 'vrfHeader': " << test
-                );
-      BOOST_TEST("" == out);
+      if (std::string::npos != test.find("via nic2")) {
+        nmdp::testInString(debugStr, "outIfaceName: nic2,");
+      }
+      if (std::string::npos != test.find("via Null0")) {
+        nmdp::testInString(debugStr, "outIfaceName: null0,");
+      }
+      if (std::string::npos != test.find("via 1::")) {
+        nmdp::testInString(debugStr, "outIfaceName: ,");
+      }
+      BOOST_TEST(nmdo::ToolObservations() == tp.curObservations);
     }
   }
 }
 
+BOOST_AUTO_TEST_CASE(testRulesIpRouteNxos)
+{
+  TestParser tp;
+  tp.isNxos = true;
+
+  {// IPv4
+    const auto& parserRule {tp.ipv4Route};
+
+    std::vector<std::string> testsOk {
+        R"(1.2.3.0/24, ubest/mbest: 1/0
+              *via 1.2.3.1, [1/2], 1w2d, static)"
+      , R"(1.2.3.0/24, ubest/mbest: 1/0
+              *via 1.2.3.1, nic, [1/2], 1w2d, static)"
+      , R"(1.2.3.0/24, ubest/mbest: 1/0, attached
+              *via 1.2.3.1, nic, [1/2], 1w2d, direct)"
+      , R"(1.2.3.0/24, ubest/mbest: 1/0
+              *via 1.2.3.1, nic, [1/2], 1w2d, eigrp-100, external, tag 1)"
+      // "one" test, three lines
+      , R"(1.2.3.255/32, ubest/mbest: 2/0, attached
+              *via 1.2.3.1, nic, [0/0], 1w2d, local)"
+      , R"(   *via 1.2.3.2, nic, [0/0], 1w2d, direct)"
+      , R"(1.2.3.0/24, ubest/mbest: 1/0
+              *via Null0, [1/2], 1w2d, ospfv3-100, discard)"
+      , R"(1.2.3.0/24, ubest/mbest: 1/0
+              *via nic, [1/2], 1w2d, ospfv3-1, intra)"
+      // routes via internal route; same config
+      , R"(1.2.3.0/24, ubest/mbest: 1/0
+              *via 1.2.3.4, [1/2], 1w2d, bgp-123, internal, tag 123)"
+      // routes via internal route; possible other config
+      , R"(1.2.3.0/24, ubest/mbest: 1/0
+              *via 1.2.3.4%default, [1/2], 1d2h, bgp-123, external, tag 123 (mpls-vpn))"
+      };
+    for (const auto& test : testsOk) {
+      nmdo::Route out;
+      BOOST_TEST( nmdp::testAttr(test.c_str(), parserRule, out, blank)
+                , "Rule 'ipv4Route': " << test
+                );
+      const auto debugStr {out.toDebugString()};
+      BOOST_TEST(out.isValid()
+                , "Validity failure: " + test + "\n\tYielded: " + debugStr
+                );
+      if (std::string::npos != debugStr.find("outIfaceName: null0")) {
+        nmdp::testInString(debugStr, "isNullRoute: true");
+      }
+      if (std::string::npos != test.find("%default,")) {
+        nmdp::testInString(debugStr, "nextVrfId: default,");
+      }
+    }
+  }
+
+  {// IPv6
+    const auto& parserRule {tp.ipv6Route};
+
+    std::vector<std::string> testsOk {
+        R"(1::/64, ubest/mbest: 1/0
+              *via 1::1/64, nic, [1/2], 1w2d, static)"
+      , R"(1::/64, ubest/mbest: 1/0, attached
+              *via 1::1/64, nic, [1/2], 1w2d, direct)"
+      , R"(1::/64, ubest/mbest: 1/0
+              *via 1::1/64, nic, [1/2], 1w2d, eigrp-100, external, tag 1)"
+      , R"(1::/48, ubest/mbest: 1/0
+              *via Null0, [1/2], 1w2d, ospfv3-100, discard)"
+      , R"(1::/48, ubest/mbest: 1/0
+              *via nic, [1/2], 1w2d, ospfv3-1, intra)"
+      // routes via internal route; same config
+      , R"(1::/128, ubest/mbest: 1/0
+              *via 1::1/128, [1/2], 1w2d, bgp-123, internal, tag 123)"
+      // routes via internal route; other config
+      , R"(1::/128, ubest/mbest: 1/0
+              *via ::f:1.2.3.4%default:IPv4, [1/2], 1d2h, bgp-123, external, tag 123 (mpls-vpn))"
+      };
+
+    for (const auto& test : testsOk) {
+      nmdo::Route out;
+      BOOST_TEST( nmdp::testAttr(test.c_str(), parserRule, out, blank)
+                , "Rule 'ipv6Route': " << test
+                );
+      const auto debugStr {out.toDebugString()};
+      BOOST_TEST(out.isValid()
+                , "Validity failure: " << test
+                  << "\nGot: " << debugStr
+                );
+      if (std::string::npos != debugStr.find("outIfaceName: null0")) {
+        nmdp::testInString(debugStr, "isNullRoute: true");
+      }
+      if (std::string::npos != test.find("%default,")) {
+        nmdp::testInString(debugStr, "nextVrfId: default,");
+      }
+      if (std::string::npos != test.find("%default:IPv4,")) {
+        nmdp::testInString(debugStr, "nextVrfId: default,");
+        nmdp::testInString(debugStr, "nextTableId: IPv4,");
+      }
+    }
+  }
+}
+
+BOOST_AUTO_TEST_CASE(testUnsupported)
+{
+  TestParser tp;
+
+  tp.isIos = true;
+  { // IPv4
+
+    const auto& parserRule {tp.ipv4Route};
+
+    std::vector<std::string> testsUnsupportedInvalid {
+        R"(C    net-list 255.255.255.0 is directly connected, nic)"
+      , R"(B    net-list 255.255.255.0 [1/2] via 1.2.3.4, 01:02:03, nic)"
+      , R"(B    net-list 255.255.255.0 [1/2] via rtr-alias, nic)"
+      };
+
+    for (const auto& test : testsUnsupportedInvalid) {
+      nmdo::Route out;
+      BOOST_TEST( nmdp::testAttr(test.c_str(), parserRule, out, blank)
+                , "Rule 'ipv4Route': " << test
+                );
+      const auto debugStr {out.toDebugString()};
+      BOOST_TEST( !out.isValid()
+                , "Expected invalid Route from: " << test
+                  << "\nGot: " << debugStr);
+    }
+
+    std::vector<std::string> testsUnsupportedValid {
+        R"(B    1.2.3.4 255.255.255.0 [1/2] via rtr-alias, nic)"
+      };
+
+    for (const auto& test : testsUnsupportedValid) {
+      nmdo::Route out;
+      BOOST_TEST( nmdp::testAttr(test.c_str(), parserRule, out, blank)
+                , "Rule 'ipv4Route': " << test
+                );
+      const auto debugStr {out.toDebugString()};
+      BOOST_TEST( out.isValid()
+                , "Expected valid Route from: " << test
+                  << "\nGot: " << debugStr);
+    }
+
+    const auto debugStr {tp.curObservations.toDebugString()};
+    nmdp::testInString(debugStr, "Subnet alias -- net-list");
+    nmdp::testInString(debugStr, "Router alias 'rtr-alias' on interface 'nic'");
+  }
+  tp.isIos = false;
+}
+
 BOOST_AUTO_TEST_CASE(testWhole)
 {
-  {
+  { // IOS like
     TestParser tp;
     const auto& parserRule {tp.start};
 
     std::string test;
-    test =
-R"(
+    {// IOS IPv4
+      test = R"(
 Codes: A - some1, B - some2
        C - some3
 
@@ -377,7 +605,7 @@ Gateway of last resort ABC to network 0.0.0.0
 
 A    1.2.3.0 255.255.255.0 [1/0] via 1.2.3.1, out
 A    1.2.4.0/24 [1/0] via 1.2.4.1, out
-C    0.0.0.0 0.0.0.0 [255/0] via ABC, unsup
+C    0.0.0.0 0.0.0.0 [255/0] via ABC
 B    1.2.5.0 255.255.0.0
         [1/0] via 1.2.5.1, 12:34:56, in
         [1/0] via 1.2.5.2, 12:34:56, in
@@ -386,24 +614,97 @@ A    1.2.6.0 255.255.255.0 [1/0] via 1.2.6.1, 12:34:56, in
 A    net-123 255.255.255.0 is directly connected, unsup
 )";
 
-    Result out;
-    BOOST_TEST( nmdp::testAttr(test.c_str(), parserRule, out, blank)
-              , "Rule 'testWhole': " << test
-              );
-    BOOST_TEST(1 == out.size());
-    for (const auto& vrf : out) {
-      BOOST_TEST(8 == vrf.routes.size());
-      for (const auto& route : vrf.routes) {
-        const auto debugStr {route.toDebugString()};
-        if (std::string::npos != debugStr.find("outIfaceName: unsup")) {
-          BOOST_TEST(!route.isValid());
-        } else {
+      Result out;
+      BOOST_TEST( nmdp::testAttr(test.c_str(), parserRule, out, blank)
+                , "Rule 'testWhole': " << test
+                );
+      BOOST_TEST(1 == out.size());
+      for (const auto& vrf : out) {
+        BOOST_TEST(8 == vrf.routes.size());
+        for (const auto& route : vrf.routes) {
+          const auto debugStr {route.toDebugString()};
+          if (std::string::npos != debugStr.find("outIfaceName: unsup")) {
+            BOOST_TEST(!route.isValid()
+                      , "Incorrect valid route: " << debugStr);
+          } else {
+            BOOST_TEST(route.isValid()
+                      , "Incorrect invalid route: " << debugStr);
+          }
+        }
+        const auto debugStr {vrf.observations.toDebugString()};
+        nmdp::testInString(debugStr, "Subnet alias -- net-123");
+      }
+    }
+    {// IOS old IPv4
+      test = R"(
+Default gateway is 1.2.3.4
+
+Host               Gateway           Last Use    Total Uses  Interface
+1.2.3.5            1.2.3.6           0:00        12345       nic1
+)";
+
+      Result out;
+      BOOST_TEST( nmdp::testAttr(test.c_str(), parserRule, out, blank)
+                , "Rule 'testWhole': " << test
+                );
+      BOOST_TEST(1 == out.size());
+      for (const auto& vrf : out) {
+        BOOST_TEST(1 == vrf.routes.size());
+        for (const auto& route : vrf.routes) {
+          const auto debugStr {route.toDebugString()};
+          BOOST_TEST(route.isValid()
+                    , "Incorrect invalid route: " << debugStr);
+        }
+      }
+    }
+    {// IOS old IPv4
+      test = R"(
+Default gateway is 1.2.3.4
+
+Host               Gateway           Last Use    Total Uses  Interface
+ICMP redirect cache is empty
+)";
+
+      Result out;
+      BOOST_TEST( nmdp::testAttr(test.c_str(), parserRule, out, blank)
+                , "Rule 'testWhole': " << test
+                );
+      BOOST_TEST_REQUIRE(1 == out.size());
+      BOOST_TEST_REQUIRE(0 == out[0].routes.size());
+      BOOST_TEST(nmdo::ToolObservations() == out[0].observations);
+    }
+    {// IOS old IPv6
+      // same as IOS
+      test = R"(
+IPv6 Routing Table - default - 3 entries
+Codes: C - Connected, L - Local, S - Static, U - Per-user Static route
+       R - RIP, ND - ND Default, NDp - ND Prefix, DCE - Destination
+       NDr - Redirect
+C   0::/127 [0/0]
+     via nic0, directly connected
+L   1::/64 [0/0]
+     via nic1, receive
+B   2::/64 [0/0]
+     via 1::1
+     via 1::2
+B   2::/64 [0/0]
+     via 1::1, nic1
+     via 1::2, nic2
+L   3::/8 [0/0]
+     via Null0, receive
+)";
+      Result out;
+      BOOST_TEST( nmdp::testAttr(test.c_str(), parserRule, out, blank)
+                , "Rule 'testWhole': " << test
+                );
+      BOOST_TEST(1 == out.size());
+      for (const auto& vrf : out) {
+        BOOST_TEST(7 == vrf.routes.size());
+        for (const auto& route : vrf.routes) {
           BOOST_TEST(route.isValid());
         }
       }
-      const auto debugStr {vrf.observations.toDebugString()};
-      nmdp::testInString(debugStr, "Router alias -- ABC");
-      nmdp::testInString(debugStr, "Subnet alias -- net-123");
+      BOOST_TEST(nmdo::ToolObservations() == out[0].observations);
     }
   }
   { // NXOS like
@@ -425,6 +726,9 @@ A    net-123 255.255.255.0 is directly connected, unsup
                *via 1.2.3.1, Null0, [1/2], 1w2d, discard, discard
            1.2.4.1/32, ubest/mbest: 1/0
                *via 1.2.4.1, nic, [1/2], 1w2d, static
+           1.2.4.2/32, ubest/mbest: 1/0
+               *via 1.2.4.2, nic, [1/2], 1w2d, static
+               *via 1.2.4.2, nic, [1/2], 1w2d, static
         )";
 
       Result out;
@@ -433,7 +737,7 @@ A    net-123 255.255.255.0 is directly connected, unsup
                 );
       BOOST_TEST(1 == out.size());
       for (const auto& vrf : out) {
-        BOOST_TEST(3 == vrf.routes.size());
+        BOOST_TEST(5 == vrf.routes.size());
         for (const auto& route : vrf.routes) {
           BOOST_TEST(route.isValid());
         }
@@ -451,6 +755,9 @@ R"(IPv6 Routing Table for VRF "default"
        *via 1::1, nic, [1/2], 12:34:56, direct
    2::/64, ubest/mbest: 1/0
        *via 2::1, nic, [1/2], 1w2d, eigrp-100, external, tag 1
+   2::/64, ubest/mbest: 1/0
+       *via 2::1, nic1, [1/2], 1w2d, eigrp-100, external, tag 1
+       *via 2::1, nic2, [1/2], 1w2d, eigrp-100, external, tag 1
 )";
 
       Result out;
@@ -459,7 +766,7 @@ R"(IPv6 Routing Table for VRF "default"
                 );
       BOOST_TEST(1 == out.size());
       for (const auto& vrf : out) {
-        BOOST_TEST(3 == vrf.routes.size());
+        BOOST_TEST(5 == vrf.routes.size());
         for (const auto& route : vrf.routes) {
           BOOST_TEST(route.isValid());
         }
@@ -519,16 +826,15 @@ garbage at the end
     BOOST_TEST( nmdp::testAttr(test.c_str(), parserRule, out, blank)
               , "Rule 'testWhole': " << test
               );
-    BOOST_TEST(4 == out.size());
-    BOOST_TEST(1 == out[0].routes.size());
+    BOOST_TEST_REQUIRE(4 == out.size());
+    BOOST_TEST_REQUIRE(1 == out[0].routes.size());
     debugStr = out[0].routes[0].toDebugString();
-    //nmdp::testInString(debugStr, "vrfId: default,");
     nmdp::testInString(debugStr, "vrfId: ,");
-    BOOST_TEST(2 == out[1].routes.size());
+    BOOST_TEST_REQUIRE(2 == out[1].routes.size());
     debugStr = out[1].routes[0].toDebugString();
     nmdp::testInString(debugStr, "vrfId: no-space-and-space,");
     BOOST_TEST(0 == out[2].routes.size());
-    BOOST_TEST(1 == out[3].routes.size());
+    BOOST_TEST_REQUIRE(1 == out[3].routes.size());
     debugStr = out[3].routes[0].toDebugString();
     nmdp::testInString(debugStr, "vrfId: ipv6,");
     for (const auto& vrf : out) {

--- a/datastore/importers/nmdb-import-cisco-show-ip-route/Parser.test.cpp
+++ b/datastore/importers/nmdb-import-cisco-show-ip-route/Parser.test.cpp
@@ -167,9 +167,12 @@ BOOST_AUTO_TEST_CASE(testRules)
       , R"(1.2.3.255/32, ubest/mbest: 2/0, attached
               *via 1.2.3.1, nic, [0/0], 1w2d, local)"
       , R"(   *via 1.2.3.2, nic, [0/0], 1w2d, direct)"
-// TODO routes via Null0, drops
+// TODO routes via Null0; drops
       , R"(1.2.3.0/24, ubest/mbest: 1/0
               *via Null0, [1/2], 1w2d, ospfv3-100, discard)"
+// TODO routes via interface
+      , R"(1.2.3.0/24, ubest/mbest: 1/0
+              *via nic, [1/2], 1w2d, ospfv3-1, intra)"
 // TODO routes via internal route; same config
       , R"(1.2.3.0/24, ubest/mbest: 1/0
               *via 1.2.3.4, [1/2], 1w2d, bgp-123, internal, tag 123)"
@@ -289,9 +292,12 @@ BOOST_AUTO_TEST_CASE(testRules)
               *via 1::1/64, nic, [1/2], 1w2d, direct)"
       , R"(1::/64, ubest/mbest: 1/0
               *via 1::1/64, nic, [1/2], 1w2d, eigrp-100, external, tag 1)"
-// TODO routes via Null0, drops
+// TODO routes via Null0; drops
       , R"(1::/48, ubest/mbest: 1/0
               *via Null0, [1/2], 1w2d, ospfv3-100, discard)"
+// TODO routes via interface
+      , R"(1::/48, ubest/mbest: 1/0
+              *via nic, [1/2], 1w2d, ospfv3-1, intra)"
 // TODO routes via internal route; same config
       , R"(1::/128, ubest/mbest: 1/0
               *via 1::1/128, [1/2], 1w2d, bgp-123, internal, tag 123)"

--- a/datastore/importers/nmdb-import-cisco-show-ip-route/Parser.test.cpp
+++ b/datastore/importers/nmdb-import-cisco-show-ip-route/Parser.test.cpp
@@ -167,6 +167,15 @@ BOOST_AUTO_TEST_CASE(testRules)
       , R"(1.2.3.255/32, ubest/mbest: 2/0, attached
               *via 1.2.3.1, nic, [0/0], 1w2d, local)"
       , R"(   *via 1.2.3.2, nic, [0/0], 1w2d, direct)"
+// TODO routes via Null0, drops
+      , R"(1.2.3.0/24, ubest/mbest: 1/0
+              *via Null0, [1/2], 1w2d, ospfv3-100, discard)"
+// TODO routes via internal route; same config
+      , R"(1.2.3.0/24, ubest/mbest: 1/0
+              *via 1.2.3.4, [1/2], 1w2d, bgp-123, internal, tag 123)"
+// TODO routes via internal route; possible other config
+      , R"(1.2.3.0/24, ubest/mbest: 1/0
+              *via 1.2.3.4%default, [1/2], 1d2h, bgp-123, external, tag 123 (mpls-vpn))"
       };
 
     for (const auto& test : testsOkValidRoute) {
@@ -280,6 +289,15 @@ BOOST_AUTO_TEST_CASE(testRules)
               *via 1::1/64, nic, [1/2], 1w2d, direct)"
       , R"(1::/64, ubest/mbest: 1/0
               *via 1::1/64, nic, [1/2], 1w2d, eigrp-100, external, tag 1)"
+// TODO routes via Null0, drops
+      , R"(1::/48, ubest/mbest: 1/0
+              *via Null0, [1/2], 1w2d, ospfv3-100, discard)"
+// TODO routes via internal route; same config
+      , R"(1::/128, ubest/mbest: 1/0
+              *via 1::1/128, [1/2], 1w2d, bgp-123, internal, tag 123)"
+// TODO routes via internal route; other config
+      , R"(1::/128, ubest/mbest: 1/0
+              *via ::f:1.2.3.4%default:IPv4, [1/2], 1d2h, bgp-123, external, tag 123 (mpls-vpn))"
       };
 
     for (const auto& test : testsOkValidRoute) {


### PR DESCRIPTION
This PR primarily resolves lack of format support for various Cisco `show ip route` calls.  Now,
- It can handled IPv4 and IPv6 for IOS, NXOS, and an old IOS output style.
- The IpAddress and associated parser logic supports cases where IPv4 addresses are both codified or embedded in IPv6.
- Routes are considered valid if a destination subnet and out interface are known.