### PR TITLE
Updates for `show cdp neighbor`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,8 @@ include(FetchContent)
 FetchContent_Declare(
   libpqxx
   GIT_REPOSITORY https://github.com/jtv/libpqxx.git
-  GIT_TAG 21afb0d6ec3d31424df6b7aac04c6b20c55c0a65 # 7.8.1 tag
+#  GIT_TAG 21afb0d6ec3d31424df6b7aac04c6b20c55c0a65 # 7.8.1 tag
+  GIT_TAG 1ca80b0e638f6182426c5b11255069cae4fbd542 # 7.9.2 tag
   GIT_PROGRESS YES
 )
 set(PQXX_LIBRARIES pqxx)

--- a/datastore/common/CMakeLists.txt
+++ b/datastore/common/CMakeLists.txt
@@ -1,5 +1,5 @@
 # =============================================================================
-# Copyright 2023 National Technology & Engineering Solutions of Sandia, LLC
+# Copyright 2024 National Technology & Engineering Solutions of Sandia, LLC
 # (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
 # Government retains certain rights in this software.
 #
@@ -49,6 +49,7 @@ add_library(${TGT_LIBRARY} SHARED
     ./objects/Package.cpp
     ./objects/Port.cpp
     ./objects/PortRange.cpp
+    ./objects/PhysicalConnection.cpp
     ./objects/Route.cpp
     ./objects/Service.cpp
     ./objects/ToolObservations.cpp

--- a/datastore/common/objects/CMakeLists.txt
+++ b/datastore/common/objects/CMakeLists.txt
@@ -1,5 +1,5 @@
 # =============================================================================
-# Copyright 2022 National Technology & Engineering Solutions of Sandia, LLC
+# Copyright 2024 National Technology & Engineering Solutions of Sandia, LLC
 # (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
 # Government retains certain rights in this software.
 #
@@ -38,6 +38,7 @@ foreach(ITEM
     Package
     Port
     PortRange
+    PhysicalConnection
     Route
     Service
     ToolObservations

--- a/datastore/common/objects/PhysicalConnection.cpp
+++ b/datastore/common/objects/PhysicalConnection.cpp
@@ -1,0 +1,144 @@
+// =============================================================================
+// Copyright 2024 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// =============================================================================
+// Maintained by Sandia National Laboratories <Netmeld@sandia.gov>
+// =============================================================================
+
+#include <netmeld/datastore/objects/PhysicalConnection.hpp>
+#include <netmeld/core/utils/StringUtilities.hpp>
+
+namespace nmcu = netmeld::core::utils;
+
+
+namespace netmeld::datastore::objects {
+
+  PhysicalConnection::PhysicalConnection()
+  {}
+
+  void
+  PhysicalConnection::setDstDeviceId(const std::string& _id)
+  {
+    dstDeviceId = nmcu::toLower(_id);
+  }
+
+  void
+  PhysicalConnection::setSrcDeviceId(const std::string& _id)
+  {
+    srcDeviceId = nmcu::toLower(_id);
+  }
+
+  void
+  PhysicalConnection::setDstIfaceName(const std::string& _name)
+  {
+    dstIfaceName = nmcu::toLower(_name);
+  }
+
+  void
+  PhysicalConnection::setSrcIfaceName(const std::string& _name)
+  {
+    srcIfaceName = nmcu::toLower(_name);
+  }
+
+
+  bool
+  PhysicalConnection::isValid() const
+  {
+    return !(  srcDeviceId.empty()
+            || srcIfaceName.empty()
+            || dstDeviceId.empty()
+            || dstIfaceName.empty()
+            )
+        ;
+  }
+
+  void
+  PhysicalConnection::save( pqxx::transaction_base& t
+                          , const nmco::Uuid& toolRunId
+                          , const std::string& deviceId
+                          )
+  {
+    if (srcDeviceId.empty() && !deviceId.empty()) {
+      srcDeviceId = deviceId;
+    }
+    if (!isValid()) {
+      LOG_DEBUG << "PhysicalConnection object is not saving: "
+                << toDebugString() << std::endl;
+      return;
+    }
+
+    // Make sure both devices are in DB
+    t.exec_prepared( "insert_raw_device"
+                   , toolRunId
+                   , srcDeviceId
+                   );
+    t.exec_prepared( "insert_raw_device"
+                   , toolRunId
+                   , dstDeviceId
+                   );
+
+    t.exec_prepared( "insert_raw_device_phys_connection"
+                   , toolRunId
+                   , srcDeviceId
+                   , srcIfaceName
+                   , dstDeviceId
+                   , dstIfaceName
+                   );
+  }
+
+  std::string
+  PhysicalConnection::toDebugString() const
+  {
+    std::ostringstream oss;
+
+    oss << "["
+        << "srcDeviceId: " << srcDeviceId
+        << ", srcIfaceName: " << srcIfaceName
+        << ", dstDeviceId: " << dstDeviceId
+        << ", dstIfaceName: " << dstIfaceName
+        << "]";
+
+    return oss.str();
+  }
+
+  std::strong_ordering
+  PhysicalConnection::operator<=>(const PhysicalConnection& rhs) const
+  {
+    return std::tie( srcDeviceId
+                   , srcIfaceName
+                   , dstDeviceId
+                   , dstIfaceName
+                   )
+       <=> std::tie( rhs.srcDeviceId
+                   , rhs.srcIfaceName
+                   , rhs.dstDeviceId
+                   , rhs.dstIfaceName
+                   )
+      ;
+  }
+
+  bool
+  PhysicalConnection::operator==(const PhysicalConnection& rhs) const
+  {
+    return 0 == operator<=>(rhs);
+  }
+}

--- a/datastore/common/objects/PhysicalConnection.hpp
+++ b/datastore/common/objects/PhysicalConnection.hpp
@@ -1,0 +1,78 @@
+// =============================================================================
+// Copyright 2024 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// =============================================================================
+// Maintained by Sandia National Laboratories <Netmeld@sandia.gov>
+// =============================================================================
+
+#ifndef PHYSICAL_CONNECTION_HPP
+#define PHYSICAL_CONNECTION_HPP
+
+#include <netmeld/datastore/objects/AbstractDatastoreObject.hpp>
+
+
+namespace netmeld::datastore::objects {
+
+  class PhysicalConnection : public AbstractDatastoreObject {
+    // =========================================================================
+    // Variables
+    // =========================================================================
+    private: // Variables will probably rarely appear at this scope
+    protected: // Variables intended for internal/subclass API
+      std::string srcDeviceId;
+      std::string srcIfaceName;
+      std::string dstDeviceId;
+      std::string dstIfaceName;
+
+    public: // Variables should rarely appear at this scope
+
+    // =========================================================================
+    // Constructors
+    // =========================================================================
+    private: // Constructors which should be hidden from API users
+    protected: // Constructors part of subclass API
+    public: // Constructors part of public API
+      PhysicalConnection();
+
+    // =========================================================================
+    // Methods
+    // =========================================================================
+    private: // Methods which should be hidden from API users
+    protected: // Methods part of subclass API
+    public: // Methods part of public API
+      void setDstDeviceId(const std::string&);
+      void setDstIfaceName(const std::string&);
+      void setSrcDeviceId(const std::string&);
+      void setSrcIfaceName(const std::string&);
+
+      bool isValid() const override;
+
+      void save(pqxx::transaction_base&,
+                const nmco::Uuid&, const std::string& x="") override;
+
+      std::string toDebugString() const override;
+
+      std::strong_ordering operator<=>(const PhysicalConnection&) const;
+      bool operator==(const PhysicalConnection&) const;
+  };
+}
+#endif // PHYSICAL_CONNECTION_HPP

--- a/datastore/common/objects/PhysicalConnection.test.cpp
+++ b/datastore/common/objects/PhysicalConnection.test.cpp
@@ -1,0 +1,67 @@
+// =============================================================================
+// Copyright 2024 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// =============================================================================
+// Maintained by Sandia National Laboratories <Netmeld@sandia.gov>
+// =============================================================================
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MAIN
+#include <boost/test/unit_test.hpp>
+
+#include <netmeld/datastore/objects/PhysicalConnection.hpp>
+
+namespace nmdo = netmeld::datastore::objects;
+
+
+class TestPhysicalConnection : public nmdo::PhysicalConnection {
+  public:
+    TestPhysicalConnection() : PhysicalConnection() {};
+
+  public:
+    using PhysicalConnection::srcDeviceId;
+    using PhysicalConnection::srcIfaceName;
+    using PhysicalConnection::dstDeviceId;
+    using PhysicalConnection::dstIfaceName;
+};
+
+BOOST_AUTO_TEST_CASE(testSetters)
+{
+  TestPhysicalConnection tpc;
+
+  const std::string val1 {"Some 1 Value"};
+  const std::string val2 {"some 1 value"};
+
+  BOOST_TEST(!tpc.isValid());
+  tpc.setSrcDeviceId(val1);
+  BOOST_TEST(val2 == tpc.srcDeviceId);
+  BOOST_TEST(!tpc.isValid());
+  tpc.setDstDeviceId(val1);
+  BOOST_TEST(val2 == tpc.dstDeviceId);
+  BOOST_TEST(!tpc.isValid());
+  tpc.setSrcIfaceName(val1);
+  BOOST_TEST(val2 == tpc.srcIfaceName);
+  BOOST_TEST(!tpc.isValid());
+  tpc.setDstIfaceName(val1);
+  BOOST_TEST(val2 == tpc.dstIfaceName);
+  BOOST_TEST(tpc.isValid());
+}

--- a/datastore/common/schemas/013device-tables-create.sql
+++ b/datastore/common/schemas/013device-tables-create.sql
@@ -703,11 +703,11 @@ CREATE TABLE raw_device_phys_connections (
                 , self_device_id, self_interface_name
                 , peer_device_id, peer_interface_name
                 )
-  , FOREIGN KEY (tool_run_id, self_device_id, self_interface_name)
-        REFERENCES raw_device_interfaces
-                   (tool_run_id, device_id, interface_name)
-        ON DELETE CASCADE
-        ON UPDATE CASCADE
+--  , FOREIGN KEY (tool_run_id, self_device_id, self_interface_name)
+--        REFERENCES raw_device_interfaces
+--                   (tool_run_id, device_id, interface_name)
+--        ON DELETE CASCADE
+--        ON UPDATE CASCADE
   , FOREIGN KEY (tool_run_id, peer_device_id)
         REFERENCES raw_devices(tool_run_id, device_id)
         ON DELETE CASCADE

--- a/datastore/common/utils/QueriesCommon.cpp
+++ b/datastore/common/utils/QueriesCommon.cpp
@@ -807,6 +807,27 @@ namespace netmeld::datastore::utils {
       );
 
     // ----------------------------------------------------------------------
+    // TABLE: raw_device_phys_connections
+    // ----------------------------------------------------------------------
+
+    db.prepare
+      ("insert_raw_device_phys_connection", R"(
+          INSERT INTO raw_device_phys_connections
+            ( tool_run_id
+            , self_device_id, self_interface_name
+            , peer_device_id, peer_interface_name
+            )
+          VALUES
+            ( $1
+            , $2, $3
+            , $4, $5
+            )
+          ON CONFLICT
+          DO NOTHING
+        )"
+      );
+
+    // ----------------------------------------------------------------------
     // TABLE: raw_device_link_connections
     // ----------------------------------------------------------------------
 

--- a/datastore/importers/nmdb-import-show-cdp-neighbor/Parser.hpp
+++ b/datastore/importers/nmdb-import-show-cdp-neighbor/Parser.hpp
@@ -30,6 +30,7 @@
 #include <netmeld/datastore/objects/DeviceInformation.hpp>
 #include <netmeld/datastore/objects/IpAddress.hpp>
 #include <netmeld/datastore/objects/InterfaceNetwork.hpp>
+#include <netmeld/datastore/objects/PhysicalConnection.hpp>
 #include <netmeld/datastore/parsers/ParserDomainName.hpp>
 #include <netmeld/datastore/parsers/ParserIpAddress.hpp>
 
@@ -41,8 +42,9 @@ namespace nmdp = netmeld::datastore::parsers;
 // Data containers
 // =============================================================================
 struct Data {
-  std::vector<nmdo::IpAddress>         ipAddrs;
-  std::vector<nmdo::DeviceInformation> devInfos;
+  std::vector<nmdo::IpAddress>          ipAddrs;
+  std::vector<nmdo::DeviceInformation>  devInfos;
+  std::vector<nmdo::PhysicalConnection> physCons;
 
   std::vector<std::pair<nmdo::InterfaceNetwork, std::string>> interfaces;
 
@@ -52,6 +54,7 @@ struct Data {
 typedef std::vector<Data>  Result;
 
 struct NeighborData {
+  std::string srcIfaceName  {""};
   std::string curHostname   {""};
   std::string curIfaceName  {""};
   std::string curVendor     {""};
@@ -86,7 +89,6 @@ class Parser :
       , detailDeviceId
       , detailEntry
       , detailHeader
-      , detailInterface
       , detailIpAddress
       , detailPlatform
       , ignoredLine
@@ -100,15 +102,16 @@ class Parser :
     qi::rule<nmdp::IstreamIter, std::string()>
         noDetailDeviceId
       , noDetailPlatform
+      , noDetailLocalIface
       , noDetailPortId
       , token
       , csvToken
       ;
 
     qi::rule<nmdp::IstreamIter>
-        noDetailCapability
+        detailInterface
+      , noDetailCapability
       , noDetailHoldtime
-      , noDetailLocalIface
       ;
 
     nmdp::ParserIpAddress   ipAddr;
@@ -125,10 +128,11 @@ class Parser :
   private:
     std::string getDevice(const std::string&);
 
-    void updateIpAddrs();
-    void updateInterfaces();
-    void updateDeviceInformation();
     void finalizeData();
+    void updateDeviceInformation();
+    void updateInterfaces();
+    void updateIpAddrs();
+    void updatePhysicalConnection();
 
     // Object return
     Result getData();

--- a/datastore/importers/nmdb-import-show-cdp-neighbor/nmdb-import-show-cdp-neighbor.cpp
+++ b/datastore/importers/nmdb-import-show-cdp-neighbor/nmdb-import-show-cdp-neighbor.cpp
@@ -85,6 +85,12 @@ class Tool : public nmdt::AbstractImportSpiritTool<P,R>
           result.save(t, toolRunId, did);
           LOG_DEBUG << result.toDebugString() << std::endl;
         }
+
+        LOG_DEBUG << "Iterating over PhysicalConnections\n";
+        for (auto& result : results.physCons) {
+          result.save(t, toolRunId, deviceId);
+          LOG_DEBUG << result.toDebugString() << std::endl;
+        }
       }
     }
 


### PR DESCRIPTION
This PR resolves issues involving `show cdp neighbor`.  Primarily:
- Captures outgoing port names to be used for port-to-port connectivity identification.
- An issue where an incoming port name with a space would fail to parse.
- Adds an object to process/store port-to-port link connections between devices.  Some of the logic was already in the DB, but nothing was leveraging it.
- Bumps the libpqxx library version being compiled with/against.