### PR TITLE
modify parser to accept correct values when parsing age values

### DIFF
--- a/datastore/importers/nmdb-import-show-mac-address-table/Parser.cpp
+++ b/datastore/importers/nmdb-import-show-mac-address-table/Parser.cpp
@@ -65,7 +65,7 @@ Parser::Parser() : Parser::base_type(start)
   typeValue =
     +qi::ascii::char_("a-zA-Z") >> +qi::ascii::blank
     > -( // age >> secure >> ntfy
-         (+qi::ascii::char_("-0-9") > +qi::ascii::blank
+         (+qi::ascii::char_("-0-9~") > +qi::ascii::blank
           > qi::ascii::char_("TFC~") > +qi::ascii::blank
           > qi::ascii::char_("TFC~")
          )

--- a/datastore/importers/nmdb-import-show-mac-address-table/Parser.cpp
+++ b/datastore/importers/nmdb-import-show-mac-address-table/Parser.cpp
@@ -71,7 +71,7 @@ Parser::Parser() : Parser::base_type(start)
          )
          // learn >> -age
        | ((qi::lit("Yes") | qi::lit("No")) >
-          -(+qi::ascii::blank >> +qi::ascii::char_("-0-9"))
+          -(+qi::ascii::blank >> +qi::ascii::char_("-0-9~"))
          )
          // protocol | pv
        | (+qi::ascii::char_("a-z,") >> !qi::ascii::digit)

--- a/datastore/importers/nmdb-import-show-mac-address-table/Parser.test.cpp
+++ b/datastore/importers/nmdb-import-show-mac-address-table/Parser.test.cpp
@@ -80,6 +80,10 @@ BOOST_AUTO_TEST_CASE(testParts)
       {"GigaEther1/2/3", "GigaEther1/2/3"},
       {"dynamic gi10", "gi10"},
       {"dynamic ip gi10", "gi10"},
+      {"dynamic ~ T F 333.22.1", "333.22.1"},
+      {"dynamic ~~~ F F 1.22.333", "1.22.333"},
+      {"dynamic Yes ~ gi10", "gi10"},
+      {"dynamic No  ~~~ GigaEther1/2/3", "GigaEther1/2/3"},
     };
     for (const auto& [test, shouldBe] : testsOk) {
       std::string out;
@@ -123,6 +127,7 @@ BOOST_AUTO_TEST_CASE(testParts)
       // vlan mac type learn age port
       "1  1234.1234.1234  type  Yes  0    port1",
       "1  1234.1234.1234  type  No   -99  port1",
+      "1  1234.1234.1234  type  Yes  ~    port1",
     };
     for (const auto& test : testsOk) {
       nmdo::InterfaceNetwork out;


### PR DESCRIPTION
add tilde character to characters accepted for age in the age >> secure >> ntfy format